### PR TITLE
Remove std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,8 @@ bincode = "1"
 criterion = "0.3"
 
 [features]
-default = ["std", "serialize"]
+default = ["serialize"]
 serialize = ["serde", "stark-curve/serialize"]
-std = []
 
 [[bench]]
 name = "schnorr"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 mod error;
 


### PR DESCRIPTION
The `std` feature is not needed, and is currently inconsistent with the description in README.
This PR completely removes it.