### PR TITLE
Replace underlying curve with cheetah

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 [dependencies]
 bitvec = { version = "0.22", default-features = false }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
-hash = { git = "https://github.com/ToposWare/hash.git", branch = "main", default-features = false }
+hash = { git = "https://github.com/ToposWare/hash.git", branch = "main", default-features = false, features = ["f63"] }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-stark-curve = { git = "https://github.com/ToposWare/stark-curve.git", branch = "main", default-features = false }
+cheetah = { git = "https://github.com/ToposWare/cheetah.git", branch = "main", default-features = false }
 subtle = { version = "2.4", default-features = false }
 
 [dev-dependencies]
@@ -22,7 +22,7 @@ criterion = "0.3"
 
 [features]
 default = ["serialize"]
-serialize = ["serde", "stark-curve/serialize"]
+serialize = ["serde", "cheetah/serialize"]
 
 [[bench]]
 name = "schnorr"

--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 extern crate criterion;
 
+use cheetah::group::ff::Field;
+use cheetah::Fp;
 use criterion::Criterion;
 use rand_core::OsRng;
-use stark_curve::group::ff::Field;
-use stark_curve::FieldElement;
 
 extern crate schnorr_sig;
 use schnorr_sig::PrivateKey;
@@ -12,27 +12,29 @@ use schnorr_sig::PublicKey;
 use schnorr_sig::Signature;
 
 fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = OsRng;
+
     c.bench_function("sign", |bench| {
-        let mut message = [FieldElement::zero(); 6];
+        let mut message = [Fp::zero(); 26];
         for message_chunk in message.iter_mut() {
-            *message_chunk = FieldElement::random(OsRng);
+            *message_chunk = Fp::random(&mut rng);
         }
 
-        let skey = PrivateKey::new(OsRng);
+        let skey = PrivateKey::new(&mut rng);
 
-        bench.iter(|| Signature::sign(&message, &skey, OsRng))
+        bench.iter(|| Signature::sign(&message, &skey, &mut rng))
     });
 
     c.bench_function("verify", |bench| {
-        let mut message = [FieldElement::zero(); 6];
+        let mut message = [Fp::zero(); 26];
         for message_chunk in message.iter_mut() {
-            *message_chunk = FieldElement::random(OsRng);
+            *message_chunk = Fp::random(&mut rng);
         }
 
-        let skey = PrivateKey::new(OsRng);
+        let skey = PrivateKey::new(&mut rng);
         let pkey = PublicKey::from_private_key(skey);
 
-        let signature = Signature::sign(&message, &skey, OsRng);
+        let signature = Signature::sign(&message, &skey, &mut rng);
 
         bench.iter(|| signature.verify(&message, &pkey))
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,31 +15,31 @@
 //! let new_key_pair = KeyPair::new(&mut rng);
 //! ```
 //!
-//! To sign a `message` seen as an array of `FieldElement` values, with a given
+//! To sign a `message` seen as an array of `Fp` values, with a given
 //! private key `skey` and given source of randomness `rng`, either call the sign
 //! method from the `Signature` struct or from the private key directly, as shown
 //! in the following examples:
 //!
 //! ```rust
-//! use stark_curve::FieldElement;
+//! use cheetah::Fp;
 //! use schnorr_sig::PrivateKey;
 //! use schnorr_sig::Signature;
 //! use rand_core::OsRng;
 //!
 //! let mut rng = OsRng;
-//! let message = [FieldElement::one(); 42];
+//! let message = [Fp::one(); 42];
 //! let skey = PrivateKey::new(&mut rng);
 //!
 //! let signature = Signature::sign(&message, &skey, &mut rng);
 //! ```
 //!
 //! ```rust
-//! use stark_curve::FieldElement;
+//! use cheetah::Fp;
 //! use schnorr_sig::PrivateKey;
 //! use rand_core::OsRng;
 //!
 //! let mut rng = OsRng;
-//! let message = [FieldElement::one(); 42];
+//! let message = [Fp::one(); 42];
 //! let skey = PrivateKey::new(&mut rng);
 //!
 //! let signature = skey.sign(&message, &mut rng);
@@ -50,13 +50,13 @@
 //! directly, as shown in the following example:
 //!
 //! ```rust
-//! use stark_curve::FieldElement;
+//! use cheetah::Fp;
 //! use schnorr_sig::PrivateKey;
 //! use schnorr_sig::PublicKey;
 //! use rand_core::OsRng;
 //!
 //! let mut rng = OsRng;
-//! let message = [FieldElement::one(); 42];
+//! let message = [Fp::one(); 42];
 //! let skey = PrivateKey::new(&mut rng);
 //! let pkey = PublicKey::from_private_key(skey);
 //!
@@ -71,12 +71,12 @@
 //!
 //!
 //! ```rust
-//! use stark_curve::FieldElement;
+//! use cheetah::Fp;
 //! use schnorr_sig::KeyPair;
 //! use rand_core::OsRng;
 //!
 //! let mut rng = OsRng;
-//! let message = [FieldElement::one(); 42];
+//! let message = [Fp::one(); 42];
 //! let key_pair = KeyPair::new(&mut rng);
 //!
 //! let signature = key_pair.sign(&message, &mut rng);

--- a/src/private.rs
+++ b/src/private.rs
@@ -3,9 +3,9 @@
 
 use super::Signature;
 
+use cheetah::group::ff::Field;
+use cheetah::{Fp, Scalar};
 use rand_core::{CryptoRng, RngCore};
-use stark_curve::group::ff::Field;
-use stark_curve::{FieldElement, Scalar};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "serialize")]
@@ -50,7 +50,7 @@ impl PrivateKey {
     }
 
     /// Computes a Schnorr signature
-    pub fn sign(&self, message: &[FieldElement], mut rng: impl CryptoRng + RngCore) -> Signature {
+    pub fn sign(&self, message: &[Fp], mut rng: impl CryptoRng + RngCore) -> Signature {
         Signature::sign(message, self, &mut rng)
     }
 }
@@ -65,12 +65,13 @@ mod tests {
     #[test]
     fn test_signature() {
         let mut rng = OsRng;
-        let mut message = [FieldElement::zero(); 6];
+
+        let mut message = [Fp::zero(); 42];
         for message_chunk in message.iter_mut() {
-            *message_chunk = FieldElement::random(&mut rng);
+            *message_chunk = Fp::random(&mut rng);
         }
 
-        let skey = PrivateKey::new(OsRng);
+        let skey = PrivateKey::new(&mut rng);
         let pkey = PublicKey::from_private_key(skey);
 
         let signature = skey.sign(&message, &mut rng);

--- a/src/public.rs
+++ b/src/public.rs
@@ -4,7 +4,7 @@
 use super::error::SignatureError;
 use super::{PrivateKey, Signature};
 
-use stark_curve::{FieldElement, ProjectivePoint};
+use cheetah::{Fp, ProjectivePoint};
 use subtle::CtOption;
 
 #[cfg(feature = "serialize")]
@@ -24,12 +24,12 @@ impl PublicKey {
     }
 
     /// Converts this public key to an array of bytes
-    pub fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> [u8; 48] {
         self.0.to_compressed()
     }
 
     /// Constructs a public key from an array of bytes
-    pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
+    pub fn from_bytes(bytes: &[u8; 48]) -> CtOption<Self> {
         ProjectivePoint::from_compressed(bytes).map(PublicKey)
     }
 
@@ -37,7 +37,7 @@ impl PublicKey {
     pub fn verify_signature(
         self,
         signature: &Signature,
-        message: &[FieldElement],
+        message: &[Fp],
     ) -> Result<(), SignatureError> {
         signature.verify(message, &self)
     }
@@ -46,19 +46,20 @@ impl PublicKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cheetah::group::ff::Field;
+    use cheetah::Scalar;
     use rand_core::OsRng;
-    use stark_curve::group::ff::Field;
-    use stark_curve::Scalar;
 
     #[test]
     fn test_signature() {
         let mut rng = OsRng;
-        let mut message = [FieldElement::zero(); 6];
+
+        let mut message = [Fp::zero(); 42];
         for message_chunk in message.iter_mut() {
-            *message_chunk = FieldElement::random(&mut rng);
+            *message_chunk = Fp::random(&mut rng);
         }
 
-        let skey = PrivateKey::new(OsRng);
+        let skey = PrivateKey::new(&mut rng);
         let pkey = PublicKey::from_private_key(skey);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
@@ -70,8 +71,8 @@ mod tests {
         assert_eq!(
             PublicKey::from_private_key(PrivateKey::from_scalar(Scalar::zero())).to_bytes(),
             [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 192
+                0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             ]
         );
 
@@ -95,8 +96,8 @@ mod tests {
         let parsed: PublicKey = bincode::deserialize(&encoded).unwrap();
         assert_eq!(parsed, pkey);
 
-        // Check that the encoding is 32 bytes exactly
-        assert_eq!(encoded.len(), 32);
+        // Check that the encoding is 48 bytes exactly
+        assert_eq!(encoded.len(), 48);
 
         // Check that the encoding itself matches the usual one
         assert_eq!(pkey, bincode::deserialize(&pkey.to_bytes()).unwrap());
@@ -104,10 +105,10 @@ mod tests {
         // Check that invalid encodings fail
         let pkey = PublicKey::from_private_key(PrivateKey::new(&mut rng));
         let mut encoded = bincode::serialize(&pkey).unwrap();
-        encoded[31] = 127;
+        encoded[47] = 127;
         assert!(bincode::deserialize::<PublicKey>(&encoded).is_err());
 
         let encoded = bincode::serialize(&pkey).unwrap();
-        assert!(bincode::deserialize::<PublicKey>(&encoded[0..31]).is_err());
+        assert!(bincode::deserialize::<PublicKey>(&encoded[0..47]).is_err());
     }
 }


### PR DESCRIPTION
Replace the underlying curve with the field-extension based Cheetah, following optimizations in the AIR program for the Topos STF.

Messages to be signed are kept as a slice of `Fp` elements, as that is the underlying type of the Rescue Hash inputs.
The length of the message to be signed in benchmarks is set to the actual one to be used, for fair comparison.