### PR TITLE
Use variable-time Straus-Shamir's trick for signature verification

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -99,9 +99,9 @@ impl Signature {
 
 pub(crate) fn hash_message(input: Fp6, message: &[Fp]) -> [u8; 32] {
     let mut h = RescueHash::digest(&<[Fp; 6] as From<Fp6>>::from(input));
-    let mut chunk = [Fp::zero(); 7];
 
     for message_chunk in message.chunks(7) {
+        let mut chunk = [Fp::zero(); 7];
         chunk[0..message_chunk.len()].copy_from_slice(message_chunk);
         let digest = RescueDigest::new(chunk);
         h = RescueHash::merge(&[h, digest]);


### PR DESCRIPTION
The current implementation relies on a default double-and-add scalar multiplication for both s.G and h.P separately and then adds them together for the final point checking.

This PR makes Schnorr signature verification rely on Straus-Shamir's trick for computing the sum s.G + h.P with only one double-and-add loop. This yields an improvement of ~28% in signature verification.

In addition, it drops the unneeded constant-time operations requirement for verification, making the overall method 24% faster than the constant-time Straus-Shamir's one, yielding a total improvement of 44% with respect to the existing implementation prior this PR.