### PR TITLE
Use internal Lookup tables

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -105,9 +105,9 @@ impl Signature {
 
 pub(crate) fn hash_message(input: Fp6, message: &[Fp]) -> [u8; 32] {
     let mut h = RescueHash::digest(&<[Fp; 6] as From<Fp6>>::from(input));
-    let mut chunk = [Fp::zero(); 7];
 
     for message_chunk in message.chunks(7) {
+        let mut chunk = [Fp::zero(); 7];
         chunk[0..message_chunk.len()].copy_from_slice(message_chunk);
         let digest = RescueDigest::new(chunk);
         h = RescueHash::merge(&[h, digest]);


### PR DESCRIPTION
This PR integrates the changes from the Cheetah curve implementation, which now relies internally on Lookup tables, and a set of hardcoded ones for the curve generator. Allows for a signature generation twice faster and a signature verification about 40% faster.

Replaces #5 (deprecated)