### PR TITLE
Update with Cheetah 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["cryptography", "crypto", "signature"]
 [dependencies]
 bitvec = { version = "0.22", default-features = false }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
-hash = { git = "https://github.com/ToposWare/hash.git", branch = "main", default-features = false, features = ["f63"] }
+hash = { git = "https://github.com/ToposWare/hash.git", branch = "main", default-features = false, features = ["f64"] }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 cheetah = { git = "https://github.com/ToposWare/cheetah.git", branch = "main", default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Schnorr-sig
 
 This crate provides an implementation of a modified version of the Schnorr signature protocol, for efficient verification in a STARK AIR program.
-The underlying curve is a custom curve, Cheetah, based on a sextic extension of the the Prime Field Fp with p = 2<sup>62</sup> + 2<sup>56</sup> + 2<sup>55</sup> + 1, and curve equation E(Fp): y<sup>2</sup> = x<sup>3</sup> + x + B, with
-B = `(1200866201009650596 * u + 1935817186716799185) * v^2 + (3999205700308519553 * u + 3518137720867787056) * v + 2508413708960025374 * u + 1526905369741321712`
+The underlying curve is a custom curve, Cheetah, based on a sextic extension of the the Prime Field Fp with p = 2<sup>64</sup> - 2<sup>32</sup> + 1, and curve equation E(Fp): y<sup>2</sup> = x<sup>3</sup> + x + B, with
+B = `u + 395`
 where
-- `u^2 - 2u - 2 = 0` is the polynomial defining the quadratic extension Fp2 over Fp,
-- `v^3 + v + 1 = 0` is the polynomial defining the cubic extension Fp6 over Fp2.
+- `u^6 - 7 = 0` is the polynomial defining the sextic extension Fp6 over Fp.
 and implemented [here](https://github.com/ToposWare/cheetah).
 
 * This implementation does not rely on the Rust standard library. The `std` feature is only used to indicate whether to use the `std` or the `alloc` crate for the underlying `hash` dependency.

--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -9,7 +9,6 @@
 #[macro_use]
 extern crate criterion;
 
-use cheetah::group::ff::Field;
 use cheetah::Fp;
 use criterion::Criterion;
 use rand_core::OsRng;

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -155,7 +155,6 @@ impl<'de> Deserialize<'de> for KeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cheetah::group::ff::Field;
     use cheetah::Scalar;
     use rand_core::OsRng;
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -11,7 +11,6 @@
 
 use super::Signature;
 
-use cheetah::group::ff::Field;
 use cheetah::{Fp, Scalar};
 use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable, CtOption};

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -13,10 +13,9 @@ use super::error::SignatureError;
 use super::{PrivateKey, PublicKey};
 
 use bitvec::{order::Lsb0, view::AsBits};
-use cheetah::group::ff::Field;
 use cheetah::BASEPOINT_TABLE;
 use cheetah::{AffinePoint, Fp, Fp6, Scalar};
-use hash::{rescue_63_14_7::hasher::RescueHash, traits::Digest};
+use hash::{rescue_64_14_7::hasher::RescueHash, traits::Digest};
 use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, CtOption};
 
@@ -61,7 +60,7 @@ impl Signature {
         let h_bits = h.as_bits::<Lsb0>();
 
         // Reconstruct a scalar from the binary sequence of h
-        let h_scalar = Scalar::from_bits(h_bits);
+        let h_scalar = Scalar::from_bits_vartime(h_bits);
 
         // Leverage faster scalar multiplication through
         // lookup tables and hardcoded base point table.


### PR DESCRIPTION
This PR updates the Schnorr sig implementation with the new Cheetah curve.

Needs to point back to Cheetah and hash main branches in Cargo.toml once https://github.com/Toposware/cheetah/pull/10 and https://github.com/Toposware/hash/pull/20 are merged.