### PR TITLE
Remove credentials fetching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Set git credentials
-        uses: fusion-engineering/setup-git-credentials@v2
-        with:
-          credentials: https://robot-toposware:${{ secrets.ROBOT_TOPOSWARE_PRIV_REPOS_TOKEN }}@github.com
-      - uses: actions/checkout@v2
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -41,11 +36,7 @@ jobs:
           override: true
       - name: Add target
         run: rustup target add ${{ matrix.target }}
-      - name: Set git credentials
-        uses: fusion-engineering/setup-git-credentials@v2
-        with:
-          credentials: https://robot-toposware:${{ secrets.ROBOT_TOPOSWARE_PRIV_REPOS_TOKEN }}@github.com
-      - uses: actions/checkout@v2
+
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:
@@ -63,11 +54,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Set git credentials
-        uses: fusion-engineering/setup-git-credentials@v2
-        with:
-          credentials: https://robot-toposware:${{ secrets.ROBOT_TOPOSWARE_PRIV_REPOS_TOKEN }}@github.com
-      - uses: actions/checkout@v2
+
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
         uses: actions-rs/cargo@v1
@@ -86,11 +73,7 @@ jobs:
           components: clippy
           toolchain: stable
           override: true
-      - name: Set git credentials
-        uses: fusion-engineering/setup-git-credentials@v2
-        with:
-          credentials: https://robot-toposware:${{ secrets.ROBOT_TOPOSWARE_PRIV_REPOS_TOKEN }}@github.com
-      - uses: actions/checkout@v2
+
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
@@ -108,11 +91,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Set git credentials
-        uses: fusion-engineering/setup-git-credentials@v2
-        with:
-          credentials: https://robot-toposware:${{ secrets.ROBOT_TOPOSWARE_PRIV_REPOS_TOKEN }}@github.com
-      - uses: actions/checkout@v2
+
       # Ensure all code has been formatted with rustfmt
       - run: rustup component add rustfmt
       - name: Check formatting


### PR DESCRIPTION
This PR removes the CI step of fetching git credentials, unnecessary now that the repos are public.