### PR TITLE
Hash pkey

### DIFF
--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -28,7 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("Public key from private key", |bench| {
         let skey = PrivateKey::new(&mut rng);
-        bench.iter(|| PublicKey::from_private_key(skey))
+        bench.iter(|| PublicKey::from_private_key(&skey))
     });
 
     c.bench_function("Sign", |bench| {
@@ -49,7 +49,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(skey);
+        let pkey = PublicKey::from_private_key(&skey);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
 

--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -14,6 +14,7 @@ use criterion::Criterion;
 use rand_core::OsRng;
 
 extern crate schnorr_sig;
+use schnorr_sig::KeyPair;
 use schnorr_sig::PrivateKey;
 use schnorr_sig::PublicKey;
 use schnorr_sig::Signature;
@@ -21,7 +22,16 @@ use schnorr_sig::Signature;
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = OsRng;
 
-    c.bench_function("sign", |bench| {
+    c.bench_function("Create keypair", |bench| {
+        bench.iter(|| KeyPair::new(&mut rng))
+    });
+
+    c.bench_function("Public key from private key", |bench| {
+        let skey = PrivateKey::new(&mut rng);
+        bench.iter(|| PublicKey::from_private_key(skey))
+    });
+
+    c.bench_function("Sign", |bench| {
         let mut message = [Fp::zero(); 26];
         for message_chunk in message.iter_mut() {
             *message_chunk = Fp::random(&mut rng);
@@ -32,7 +42,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         bench.iter(|| Signature::sign(&message, &skey, &mut rng))
     });
 
-    c.bench_function("verify", |bench| {
+    c.bench_function("Verify", |bench| {
         let mut message = [Fp::zero(); 26];
         for message_chunk in message.iter_mut() {
             *message_chunk = Fp::random(&mut rng);

--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -31,7 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         bench.iter(|| PublicKey::from_private_key(&skey))
     });
 
-    c.bench_function("Sign", |bench| {
+    c.bench_function("Sign with private key", |bench| {
         let mut message = [Fp::zero(); 26];
         for message_chunk in message.iter_mut() {
             *message_chunk = Fp::random(&mut rng);
@@ -39,7 +39,18 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let skey = PrivateKey::new(&mut rng);
 
-        bench.iter(|| Signature::sign(&message, &skey, &mut rng))
+        bench.iter(|| skey.sign(&message, &mut rng))
+    });
+
+    c.bench_function("Sign with keypair", |bench| {
+        let mut message = [Fp::zero(); 26];
+        for message_chunk in message.iter_mut() {
+            *message_chunk = Fp::random(&mut rng);
+        }
+
+        let keypair = KeyPair::new(&mut rng);
+
+        bench.iter(|| keypair.sign(&message, &mut rng))
     });
 
     c.bench_function("Verify", |bench| {

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -82,7 +82,7 @@ impl KeyPair {
 
     /// Computes a Schnorr signature
     pub fn sign(&self, message: &[Fp], mut rng: impl CryptoRng + RngCore) -> Signature {
-        Signature::sign(message, &self.private_key, &mut rng)
+        Signature::sign_with_keypair(message, self, &mut rng)
     }
 
     /// Verifies a signature against a message and this key pair

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -10,7 +10,7 @@
 //! combining a `PrivateKey` and an associated `PublicKey`.
 
 use super::error::SignatureError;
-use super::{PrivateKey, PublicKey, Signature};
+use super::{KeyedSignature, PrivateKey, PublicKey, Signature};
 
 use cheetah::Fp;
 use rand_core::{CryptoRng, RngCore};
@@ -83,6 +83,15 @@ impl KeyPair {
     /// Computes a Schnorr signature
     pub fn sign(&self, message: &[Fp], mut rng: impl CryptoRng + RngCore) -> Signature {
         Signature::sign_with_keypair(message, self, &mut rng)
+    }
+
+    /// Computes a Schnorr signature binded to its associated public key.
+    pub fn sign_and_bind_pkey(
+        &self,
+        message: &[Fp],
+        mut rng: impl CryptoRng + RngCore,
+    ) -> KeyedSignature {
+        KeyedSignature::sign_with_keypair(message, self, &mut rng)
     }
 
     /// Verifies a signature against a message and this key pair

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -34,7 +34,7 @@ impl KeyPair {
     /// Generates a new random key pair
     pub fn new(mut rng: impl CryptoRng + RngCore) -> Self {
         let private_key = PrivateKey::new(&mut rng);
-        let public_key = PublicKey::from_private_key(private_key);
+        let public_key = PublicKey::from_private_key(&private_key);
 
         KeyPair {
             private_key,
@@ -48,7 +48,7 @@ impl KeyPair {
     /// is unknown, it is preferable to use the `KeyPair:new`
     /// method instead.
     pub fn from_private_key(private_key: PrivateKey) -> Self {
-        let public_key = PublicKey::from_private_key(private_key);
+        let public_key = PublicKey::from_private_key(&private_key);
 
         KeyPair {
             private_key,
@@ -69,7 +69,7 @@ impl KeyPair {
     /// Constructs a key pair from an array of bytes
     pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
         PrivateKey::from_bytes(bytes).and_then(|private_key| {
-            let public_key = PublicKey::from_private_key(private_key);
+            let public_key = PublicKey::from_private_key(&private_key);
             CtOption::new(
                 KeyPair {
                     private_key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! ```
 //!
 //! To sign a `message` seen as an array of `Fp` values, with a given
-//! private key `skey` and given source of randomness `rng`, either call the sign
+//! private key `skey` and given source of randomness `rng`, either call the `sign`
 //! method from the `Signature` struct or from the private key directly, as shown
 //! in the following examples:
 //!
@@ -53,6 +53,51 @@
 //! let signature = skey.sign(&message, &mut rng);
 //! ```
 //!
+//! The Schnorr signatures of this library hash the public key associated
+//! to the signing key. For a faster signing process, one can call either
+//! the `sign_with_provided_pkey` or `sign_with_keypair` methods, or the
+//! `sign` method from the `KeyPair` struct, as shown below:
+//!
+//! ```rust
+//! use cheetah::Fp;
+//! use schnorr_sig::PrivateKey;
+//! use schnorr_sig::PublicKey;
+//! use schnorr_sig::Signature;
+//! use rand_core::OsRng;
+//!
+//! let mut rng = OsRng;
+//! let message = [Fp::one(); 42];
+//! let skey = PrivateKey::new(&mut rng);
+//! let pkey = PublicKey::from_private_key(&skey);
+//!
+//! let signature = Signature::sign_with_provided_pkey(&message, &skey, &pkey, &mut rng);
+//! ```
+//!
+//! ```rust
+//! use cheetah::Fp;
+//! use schnorr_sig::KeyPair;
+//! use schnorr_sig::Signature;
+//! use rand_core::OsRng;
+//!
+//! let mut rng = OsRng;
+//! let message = [Fp::one(); 42];
+//! let keypair = KeyPair::new(&mut rng);
+//!
+//! let signature = Signature::sign_with_keypair(&message, &keypair, &mut rng);
+//! ```
+//!
+//! ```rust
+//! use cheetah::Fp;
+//! use schnorr_sig::KeyPair;
+//! use rand_core::OsRng;
+//!
+//! let mut rng = OsRng;
+//! let message = [Fp::one(); 42];
+//! let keypair = KeyPair::new(&mut rng);
+//!
+//! let signature = keypair.sign(&message, &mut rng);
+//! ```
+//!
 //! To verify a signature against a given `message`, with a provided
 //! public key `pkey`, you can call the verify method from the `signature`
 //! directly, as shown in the following example:
@@ -61,6 +106,7 @@
 //! use cheetah::Fp;
 //! use schnorr_sig::PrivateKey;
 //! use schnorr_sig::PublicKey;
+//! use schnorr_sig::Signature;
 //! use rand_core::OsRng;
 //!
 //! let mut rng = OsRng;
@@ -86,10 +132,12 @@
 //! let mut rng = OsRng;
 //! let message = [Fp::one(); 42];
 //! let key_pair = KeyPair::new(&mut rng);
+//! let pkey = key_pair.public_key;
 //!
 //! let signature = key_pair.sign(&message, &mut rng);
 //!
 //! assert!(key_pair.verify_signature(&signature, &message).is_ok());
+//! assert!(pkey.verify_signature(&signature, &message).is_ok());
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //! let mut rng = OsRng;
 //! let message = [Fp::one(); 42];
 //! let skey = PrivateKey::new(&mut rng);
-//! let pkey = PublicKey::from_private_key(skey);
+//! let pkey = PublicKey::from_private_key(&skey);
 //!
 //! let signature = skey.sign(&message, &mut rng);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,6 @@
 //! `verify_signature` method implemented for the
 //! `PublicKey` and `KeyPair` types:
 //!
-//!
 //! ```rust
 //! use cheetah::Fp;
 //! use schnorr_sig::KeyPair;
@@ -131,13 +130,34 @@
 //!
 //! let mut rng = OsRng;
 //! let message = [Fp::one(); 42];
-//! let key_pair = KeyPair::new(&mut rng);
-//! let pkey = key_pair.public_key;
+//! let keypair = KeyPair::new(&mut rng);
+//! let pkey = keypair.public_key;
 //!
-//! let signature = key_pair.sign(&message, &mut rng);
+//! let signature = keypair.sign(&message, &mut rng);
 //!
-//! assert!(key_pair.verify_signature(&signature, &message).is_ok());
+//! assert!(keypair.verify_signature(&signature, &message).is_ok());
 //! assert!(pkey.verify_signature(&signature, &message).is_ok());
+//! ```
+//!
+//! The `KeyedSignature` struct can also be used to attach the identity
+//! of the signer (its `PublicKey`) to a produced signature. The
+//! `KeyedSignature` struct shares the same signing methods than the
+//! `Signature` struct, and can be verified like this:
+//!
+//! ```rust
+//! use cheetah::Fp;
+//! use schnorr_sig::KeyPair;
+//! use schnorr_sig::KeyedSignature;
+//! use rand_core::OsRng;
+//!
+//! let mut rng = OsRng;
+//! let message = [Fp::one(); 42];
+//! let keypair = KeyPair::new(&mut rng);
+//!
+//! let keyed_signature = KeyedSignature::sign_with_keypair(&message, &keypair, &mut rng);
+//!
+//! assert!(keypair.verify_signature(&keyed_signature.signature, &message).is_ok());
+//! assert!(keyed_signature.verify(&message).is_ok());
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -166,4 +186,4 @@ pub use public::PublicKey;
 
 pub use keypair::KeyPair;
 
-pub use signature::Signature;
+pub use signature::{KeyedSignature, Signature};

--- a/src/private.rs
+++ b/src/private.rs
@@ -9,7 +9,7 @@
 //! This module provides a `PrivateKey` wrapping
 //! struct around a `Scalar` element.
 
-use super::Signature;
+use super::{KeyedSignature, Signature};
 
 use cheetah::{Fp, Scalar};
 use rand_core::{CryptoRng, RngCore};
@@ -61,6 +61,17 @@ impl PrivateKey {
     /// or to sign through the `Signature::sign_with_provided_pkey` method.
     pub fn sign(&self, message: &[Fp], mut rng: impl CryptoRng + RngCore) -> Signature {
         Signature::sign(message, self, &mut rng)
+    }
+
+    /// Computes a Schnorr signature binded to its associated public key.
+    /// It is faster to sign with a `KeyPair` (containing the associated public key),
+    /// or to sign through the `Signature::sign_with_provided_pkey` method.
+    pub fn sign_and_bind_pkey(
+        &self,
+        message: &[Fp],
+        mut rng: impl CryptoRng + RngCore,
+    ) -> KeyedSignature {
+        KeyedSignature::sign(message, self, &mut rng)
     }
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -56,7 +56,9 @@ impl PrivateKey {
         Scalar::from_bytes(bytes).and_then(|s| CtOption::new(PrivateKey(s), Choice::from(1u8)))
     }
 
-    /// Computes a Schnorr signature
+    /// Computes a Schnorr signature.
+    /// It is faster to sign with a `KeyPair` (containing the associated public key),
+    /// or to sign through the `Signature::sign_with_provided_pkey` method.
     pub fn sign(&self, message: &[Fp], mut rng: impl CryptoRng + RngCore) -> Signature {
         Signature::sign(message, self, &mut rng)
     }

--- a/src/private.rs
+++ b/src/private.rs
@@ -79,7 +79,7 @@ mod tests {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(skey);
+        let pkey = PublicKey::from_private_key(&skey);
 
         let signature = skey.sign(&message, &mut rng);
         assert!(signature.verify(&message, &pkey).is_ok());

--- a/src/public.rs
+++ b/src/public.rs
@@ -13,7 +13,7 @@ use super::error::SignatureError;
 use super::{PrivateKey, Signature};
 
 use cheetah::{CompressedPoint, Fp, ProjectivePoint, BASEPOINT_TABLE};
-use subtle::CtOption;
+use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 pub struct PublicKey(pub(crate) ProjectivePoint);
+
+impl ConditionallySelectable for PublicKey {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        PublicKey(ProjectivePoint::conditional_select(&a.0, &b.0, choice))
+    }
+}
 
 impl PublicKey {
     /// Computes a public key from a provided private key

--- a/src/public.rs
+++ b/src/public.rs
@@ -12,7 +12,7 @@
 use super::error::SignatureError;
 use super::{PrivateKey, Signature};
 
-use cheetah::{CompressedPoint, Fp, ProjectivePoint};
+use cheetah::{CompressedPoint, Fp, ProjectivePoint, BASEPOINT_TABLE};
 use subtle::CtOption;
 
 #[cfg(feature = "serialize")]
@@ -25,8 +25,8 @@ pub struct PublicKey(pub(crate) ProjectivePoint);
 
 impl PublicKey {
     /// Computes a public key from a provided private key
-    pub fn from_private_key(sk: PrivateKey) -> Self {
-        let pkey = ProjectivePoint::generator() * sk.0;
+    pub fn from_private_key(sk: &PrivateKey) -> Self {
+        let pkey = &BASEPOINT_TABLE * sk.0;
 
         PublicKey(pkey)
     }
@@ -67,7 +67,7 @@ mod tests {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(skey);
+        let pkey = PublicKey::from_private_key(&skey);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
         assert!(pkey.verify_signature(&signature, &message).is_ok());
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_encoding() {
         assert_eq!(
-            PublicKey::from_private_key(PrivateKey::from_scalar(Scalar::zero()))
+            PublicKey::from_private_key(&PrivateKey::from_scalar(Scalar::zero()))
                 .to_bytes()
                 .0,
             [
@@ -100,7 +100,7 @@ mod tests {
     #[cfg(feature = "serialize")]
     fn test_serde() {
         let mut rng = OsRng;
-        let pkey = PublicKey::from_private_key(PrivateKey::new(&mut rng));
+        let pkey = PublicKey::from_private_key(&PrivateKey::new(&mut rng));
         let encoded = bincode::serialize(&pkey).unwrap();
         let parsed: PublicKey = bincode::deserialize(&encoded).unwrap();
         assert_eq!(parsed, pkey);
@@ -112,7 +112,7 @@ mod tests {
         assert_eq!(pkey, bincode::deserialize(&pkey.to_bytes().0).unwrap());
 
         // Check that invalid encodings fail
-        let pkey = PublicKey::from_private_key(PrivateKey::new(&mut rng));
+        let pkey = PublicKey::from_private_key(&PrivateKey::new(&mut rng));
         let mut encoded = bincode::serialize(&pkey).unwrap();
         encoded[48] = 255;
         assert!(bincode::deserialize::<PublicKey>(&encoded).is_err());

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -42,7 +42,7 @@ impl Signature {
         let r = Scalar::random(&mut rng);
         let r_point = AffinePoint::from(&BASEPOINT_TABLE * r);
 
-        let h = hash_message(r_point.get_x(), message);
+        let h = hash_message(&r_point.get_x(), message);
         let h_bits = h.as_bits::<Lsb0>();
 
         // Reconstruct a scalar from the binary sequence of h
@@ -57,7 +57,7 @@ impl Signature {
 
     /// Verifies a Schnorr signature
     pub fn verify(self, message: &[Fp], pkey: &PublicKey) -> Result<(), SignatureError> {
-        let h = hash_message(self.x, message);
+        let h = hash_message(&self.x, message);
         let h_bits = h.as_bits::<Lsb0>();
 
         // Reconstruct a scalar from the binary sequence of h
@@ -100,8 +100,8 @@ impl Signature {
     }
 }
 
-pub(crate) fn hash_message(point_coordinate: Fp6, message: &[Fp]) -> [u8; 32] {
-    let mut data = <[Fp; 6] as From<Fp6>>::from(point_coordinate).to_vec();
+pub(crate) fn hash_message(point_coordinate: &Fp6, message: &[Fp]) -> [u8; 32] {
+    let mut data = <[Fp; 6] as From<&Fp6>>::from(point_coordinate).to_vec();
     data.extend_from_slice(message);
 
     let h = RescueHash::hash_field(&data);
@@ -124,7 +124,7 @@ mod test {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(skey);
+        let pkey = PublicKey::from_private_key(&skey);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
         assert!(signature.verify(&message, &pkey).is_ok());
@@ -140,7 +140,7 @@ mod test {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(skey);
+        let pkey = PublicKey::from_private_key(&skey);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -14,13 +14,13 @@ use super::{KeyPair, PrivateKey, PublicKey};
 
 use bitvec::{order::Lsb0, view::AsBits};
 use cheetah::BASEPOINT_TABLE;
-use cheetah::{AffinePoint, Fp, Fp6, Scalar};
+use cheetah::{AffinePoint, CompressedPoint, Fp, Fp6, ProjectivePoint, Scalar};
 use hash::{
     rescue_64_8_4::RescueHash,
     traits::{Digest, Hasher},
 };
 use rand_core::{CryptoRng, RngCore};
-use subtle::{Choice, CtOption};
+use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
@@ -34,6 +34,15 @@ pub struct Signature {
     /// The exponent from the random scalar, the private key
     /// and the output of the hash seen as a `Scalar` element
     pub e: Scalar,
+}
+
+impl ConditionallySelectable for Signature {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Signature {
+            x: Fp6::conditional_select(&a.x, &b.x, choice),
+            e: Scalar::conditional_select(&a.e, &b.e, choice),
+        }
+    }
 }
 
 impl Signature {
@@ -155,6 +164,112 @@ impl Signature {
     }
 }
 
+/// A Schnorr signature not attached to its message, and the associated
+/// signer's public key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+pub struct KeyedSignature {
+    /// The public key to verify this signature against
+    pub public_key: PublicKey,
+    /// The signature
+    pub signature: Signature,
+}
+
+impl KeyedSignature {
+    /// Computes a Schnorr signature. This requires to compute the `PublicKey` from
+    /// the provided `PrivateKey` internally. For a faster signing, one should prefer
+    /// to use `Signature::sign_with_provided_pkey` or `Signature::sign_with_keypair`.
+    pub fn sign(message: &[Fp], skey: &PrivateKey, mut rng: impl CryptoRng + RngCore) -> Self {
+        let public_key = PublicKey::from_private_key(skey);
+        let r = Scalar::random(&mut rng);
+        let r_point = AffinePoint::from(&BASEPOINT_TABLE * r);
+
+        let h = hash_message(&r_point.get_x(), &public_key, message);
+        let h_bits = h.as_bits::<Lsb0>();
+
+        // Reconstruct a scalar from the binary sequence of h
+        let h_scalar = Scalar::from_bits(h_bits);
+
+        let e = r - skey.0 * h_scalar;
+        let signature = Signature {
+            x: r_point.get_x(),
+            e,
+        };
+
+        KeyedSignature {
+            public_key,
+            signature,
+        }
+    }
+
+    /// Computes a Schnorr signature with a provided `PublicKey` for faster signing.
+    /// This method does not check that the provided `skey` and `pkey` are matching.
+    /// In particular, the resulting signature will be invalid if they don't match.
+    pub fn sign_with_provided_pkey(
+        message: &[Fp],
+        skey: &PrivateKey,
+        pkey: &PublicKey,
+        mut rng: impl CryptoRng + RngCore,
+    ) -> Self {
+        KeyedSignature {
+            public_key: *pkey,
+            signature: Signature::sign_with_provided_pkey(message, skey, pkey, &mut rng),
+        }
+    }
+
+    /// Computes a Schnorr signature with a provided `PublicKey` for faster signing.
+    /// This method does not check that the provided `skey` and `pkey` are matching.
+    /// In particular, the resulting signature will be invalid if they don't match.
+    pub fn sign_with_keypair(
+        message: &[Fp],
+        keypair: &KeyPair,
+        mut rng: impl CryptoRng + RngCore,
+    ) -> Self {
+        KeyedSignature {
+            public_key: keypair.public_key,
+            signature: Signature::sign_with_keypair(message, keypair, &mut rng),
+        }
+    }
+
+    /// Verifies a Schnorr signature
+    pub fn verify(self, message: &[Fp]) -> Result<(), SignatureError> {
+        self.signature.verify(message, &self.public_key)
+    }
+
+    /// Converts this signature to an array of bytes
+    pub fn to_bytes(&self) -> [u8; 129] {
+        let mut output = [0u8; 129];
+        output[0..49].copy_from_slice(&self.public_key.to_bytes().0);
+        output[49..129].copy_from_slice(&self.signature.to_bytes());
+
+        output
+    }
+
+    /// Constructs a signature from an array of bytes
+    pub fn from_bytes(bytes: &[u8; 129]) -> CtOption<Self> {
+        let mut array = [0u8; 49];
+        array.copy_from_slice(&bytes[0..49]);
+        let public_key = PublicKey::from_bytes(&CompressedPoint(array));
+
+        let mut array = [0u8; 80];
+        array.copy_from_slice(&bytes[49..129]);
+        let signature = Signature::from_bytes(&array);
+
+        let choice = public_key.is_some() & signature.is_some();
+
+        CtOption::new(
+            KeyedSignature {
+                public_key: public_key.unwrap_or(PublicKey(ProjectivePoint::generator())),
+                signature: signature.unwrap_or(Signature {
+                    x: Fp6::zero(),
+                    e: Scalar::zero(),
+                }),
+            },
+            choice,
+        )
+    }
+}
+
 pub(crate) fn hash_message(point_coordinate: &Fp6, pkey: &PublicKey, message: &[Fp]) -> [u8; 32] {
     let mut data = <[Fp; 6] as From<&Fp6>>::from(point_coordinate).to_vec();
     data.extend_from_slice(&<[Fp; 6] as From<Fp6>>::from(pkey.0.get_x()));
@@ -186,6 +301,8 @@ mod test {
         let skey = keypair.private_key;
         let pkey = keypair.public_key;
 
+        // Regular signature
+
         let signature = Signature::sign(&message, &skey, &mut rng);
         assert!(signature.verify(&message, &pkey).is_ok());
 
@@ -194,6 +311,17 @@ mod test {
 
         let signature = Signature::sign_with_keypair(&message, &keypair, &mut rng);
         assert!(keypair.verify_signature(&signature, &message).is_ok());
+
+        // Keyed signature
+
+        let signature = KeyedSignature::sign(&message, &skey, &mut rng);
+        assert!(signature.verify(&message).is_ok());
+
+        let signature = KeyedSignature::sign_with_provided_pkey(&message, &skey, &pkey, &mut rng);
+        assert!(signature.verify(&message).is_ok());
+
+        let signature = KeyedSignature::sign_with_keypair(&message, &keypair, &mut rng);
+        assert!(signature.verify(&message).is_ok());
     }
 
     #[test]
@@ -214,6 +342,11 @@ mod test {
             let mut wrong_message = message;
             wrong_message[4] = Fp::zero();
             assert!(signature.verify(&wrong_message, &pkey).is_err());
+        }
+
+        {
+            let wrong_pkey = PublicKey(ProjectivePoint::generator());
+            assert!(signature.verify(&message, &wrong_pkey).is_err());
         }
 
         {
@@ -261,6 +394,24 @@ mod test {
             ]
         );
 
+        assert_eq!(
+            KeyedSignature {
+                public_key: PublicKey(ProjectivePoint::identity()),
+                signature: Signature {
+                    x: Fp6::zero(),
+                    e: Scalar::one(),
+                },
+            }
+            .to_bytes(),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            ]
+        );
+
         // Test random keys encoding
         let mut rng = OsRng;
 
@@ -269,9 +420,18 @@ mod test {
                 x: Fp6::random(&mut rng),
                 e: Scalar::random(&mut rng),
             };
-            let bytes = sig.to_bytes();
+            let pkey = PublicKey(ProjectivePoint::random(&mut rng));
 
+            let bytes = sig.to_bytes();
             assert_eq!(sig, Signature::from_bytes(&bytes).unwrap());
+
+            let keyed_sig = KeyedSignature {
+                signature: sig,
+                public_key: pkey,
+            };
+
+            let bytes = keyed_sig.to_bytes();
+            assert_eq!(keyed_sig, KeyedSignature::from_bytes(&bytes).unwrap());
         }
 
         // Test invalid encoding
@@ -300,26 +460,56 @@ mod test {
         let skey = PrivateKey::new(&mut rng);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
-        let encoded = bincode::serialize(&signature).unwrap();
-        let parsed: Signature = bincode::deserialize(&encoded).unwrap();
-        assert_eq!(parsed, signature);
+        {
+            let encoded = bincode::serialize(&signature).unwrap();
+            let parsed: Signature = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(parsed, signature);
 
-        // Check that the encoding is 80 bytes exactly
-        assert_eq!(encoded.len(), 80);
+            // Check that the encoding is 80 bytes exactly
+            assert_eq!(encoded.len(), 80);
 
-        // Check that the encoding itself matches the usual one
-        assert_eq!(
+            // Check that the encoding itself matches the usual one
+            assert_eq!(
+                signature,
+                bincode::deserialize(&signature.to_bytes()).unwrap()
+            );
+
+            // Check that invalid encodings fail
+            let signature = Signature::sign(&message, &skey, &mut rng);
+            let mut encoded = bincode::serialize(&signature).unwrap();
+            encoded[79] = 127;
+            assert!(bincode::deserialize::<Signature>(&encoded).is_err());
+
+            let encoded = bincode::serialize(&signature).unwrap();
+            assert!(bincode::deserialize::<Signature>(&encoded[0..79]).is_err());
+        }
+
+        let keyed_signature = KeyedSignature {
+            public_key: PublicKey::from_private_key(&skey),
             signature,
-            bincode::deserialize(&signature.to_bytes()).unwrap()
-        );
+        };
+        {
+            let encoded = bincode::serialize(&keyed_signature).unwrap();
+            let parsed: KeyedSignature = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(parsed, keyed_signature);
 
-        // Check that invalid encodings fail
-        let signature = Signature::sign(&message, &skey, OsRng);
-        let mut encoded = bincode::serialize(&signature).unwrap();
-        encoded[79] = 127;
-        assert!(bincode::deserialize::<Signature>(&encoded).is_err());
+            // Check that the encoding is 129 bytes exactly
+            assert_eq!(encoded.len(), 129);
 
-        let encoded = bincode::serialize(&signature).unwrap();
-        assert!(bincode::deserialize::<Signature>(&encoded[0..79]).is_err());
+            // Check that the encoding itself matches the usual one
+            assert_eq!(
+                keyed_signature,
+                bincode::deserialize(&keyed_signature.to_bytes()).unwrap()
+            );
+
+            // Check that invalid encodings fail
+            let keyed_signature = KeyedSignature::sign(&message, &skey, &mut rng);
+            let mut encoded = bincode::serialize(&keyed_signature).unwrap();
+            encoded[128] = 127;
+            assert!(bincode::deserialize::<KeyedSignature>(&encoded).is_err());
+
+            let encoded = bincode::serialize(&keyed_signature).unwrap();
+            assert!(bincode::deserialize::<KeyedSignature>(&encoded[0..128]).is_err());
+        }
     }
 }


### PR DESCRIPTION
The previous version was hashing `r` and `m`, and hence was malleable with respect to the public key (using the opposite point and negating `e` in the signature would yield a signature for a same message under a different public key).

This follows the approach of BIP-340 of hashing the x-coordinate of the randomly sampled point, along with the signer's public key and the message to be signed.

This PR also provides a faster key conversion (private -> public) by relying on the hardcoded basepoint table.