### PR TITLE
Check public key during signature verification

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ use core::fmt::{Display, Formatter, Result};
 /// Custom error type during signature operations
 #[derive(Debug, PartialEq)]
 pub enum SignatureError {
+    /// Invalid public key
+    InvalidPublicKey,
     /// Invalid signature
     InvalidSignature,
 }
@@ -18,6 +20,9 @@ pub enum SignatureError {
 impl Display for SignatureError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
+            Self::InvalidPublicKey => {
+                write!(f, "The public key is not an element of the prime subgroup.",)
+            }
             Self::InvalidSignature => {
                 write!(f, "The signature is invalid or was incorrectly computed.",)
             }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -121,6 +121,10 @@ impl Signature {
 
     /// Verifies a Schnorr signature
     pub fn verify(self, message: &[Fp], pkey: &PublicKey) -> Result<(), SignatureError> {
+        if !bool::from(pkey.0.is_torsion_free()) {
+            return Err(SignatureError::InvalidPublicKey);
+        }
+
         let h = hash_message(&self.x, pkey, message);
         let h_bits = h.as_bits::<Lsb0>();
 


### PR DESCRIPTION
This PR adds a check on the provided public key when verifying signatures, to enforce that its underlying point is part of the curve prime subgroup.