### PR TITLE
HKDF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ keywords = ["cryptography", "crypto", "signature"]
 
 [dependencies]
 bitvec = { version = "0.22", default-features = false }
+cheetah = { git = "https://github.com/ToposWare/cheetah.git", branch = "main", default-features = false }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 hash = { git = "https://github.com/ToposWare/hash.git", branch = "main", default-features = false, features = ["f64"] }
+hmac = { version = "0.12", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-cheetah = { git = "https://github.com/ToposWare/cheetah.git", branch = "main", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.4", default-features = false }
 
 [dev-dependencies]

--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -38,7 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("Public key from private key", |bench| {
         let skey = PrivateKey::new(&mut rng);
-        bench.iter(|| PublicKey::from_private_key(&skey))
+        bench.iter(|| PublicKey::from(&skey))
     });
 
     let sign_str = "Sign with private key - ".to_string();

--- a/benches/schnorr.rs
+++ b/benches/schnorr.rs
@@ -14,7 +14,9 @@ use criterion::Criterion;
 use rand_core::{OsRng, RngCore};
 
 extern crate schnorr_sig;
-use schnorr_sig::{ExtendedPrivateKey, ExtendedPublicKey, KeyPair, PrivateKey, PublicKey};
+use schnorr_sig::{
+    ExtendedPrivateKey, ExtendedPublicKey, KeyPair, PrivateKey, PublicKey, PRIVATE_KEY_SEED_LENGTH,
+};
 
 static MESSAGE_LENGTHS: [usize; 3] = [1, 10, 20];
 
@@ -22,7 +24,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = OsRng;
     let skey = PrivateKey::new(&mut rng);
     let keypair = KeyPair::new(&mut rng);
-    let mut seed = [0u8; 32];
+    let mut seed = [0u8; PRIVATE_KEY_SEED_LENGTH];
     rng.fill_bytes(&mut seed);
     let ext_skey = ExtendedPrivateKey::generate_master_key(&seed).unwrap();
     let ext_pkey = ExtendedPublicKey::from_extended_private_key(&ext_skey);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2021-2022 Toposware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module defines all constants used in this crate.
+
+/// Private key length in bytes (serialized form)
+pub const PRIVATE_KEY_LENGTH: usize = 32;
+
+/// Public key length in bytes (serialized form)
+pub const PUBLIC_KEY_LENGTH: usize = 49;
+
+/// Key pair length in bytes (serialized form)
+pub const KEY_PAIR_LENGTH: usize = 32;
+
+/// Chain code length for deriving keys
+/// It could be only 16 but is set to 32 for safety.
+pub const CHAIN_CODE_LENGTH: usize = 32;
+
+/// Extended private key length in bytes (serialized form)
+pub const EXTENDED_PRIVATE_KEY_LENGTH: usize = PRIVATE_KEY_LENGTH + CHAIN_CODE_LENGTH;
+
+/// Extended public key length in bytes (serialized form)
+pub const EXTENDED_PUBLIC_KEY_LENGTH: usize = PUBLIC_KEY_LENGTH + CHAIN_CODE_LENGTH;
+
+/// Private key seed length in bytes
+pub const PRIVATE_KEY_SEED_LENGTH: usize = 32;
+
+/// Private key nonce length in bytes
+pub const PRIVATE_KEY_NONCE_LENGTH: usize = 32;

--- a/src/derivation.rs
+++ b/src/derivation.rs
@@ -1,0 +1,581 @@
+// Copyright (c) 2021-2022 Toposware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module provides an implementation of "hierarchical deterministic
+//! key derivation" (HDKD) for Schnorr signatures on the Cheetah curve.
+
+use super::{PrivateKey, PublicKey};
+
+use cheetah::Scalar;
+use cheetah::BASEPOINT_TABLE;
+use hmac::{Hmac, Mac};
+use sha2::Sha512;
+use subtle::{Choice, ConditionallySelectable, CtOption};
+
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// BIP32 like chain codes, providing large entropy when deriving keys.
+/// Chain codes are 32 bytes long.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+pub struct ChainCode([u8; 32]);
+
+impl ConditionallySelectable for ChainCode {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        let mut bytes = [0u8; 32];
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            *byte = u8::conditional_select(&a.0[i], &b.0[i], choice);
+        }
+
+        ChainCode(bytes)
+    }
+}
+
+/// A wraper combining a derivable private key and a chain code.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+pub struct ExtendedPrivateKey {
+    /// A private key
+    pub key: PrivateKey,
+    /// A chain code
+    pub chaincode: ChainCode,
+}
+
+impl ConditionallySelectable for ExtendedPrivateKey {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        ExtendedPrivateKey {
+            key: PrivateKey::conditional_select(&a.key, &b.key, choice),
+            chaincode: ChainCode::conditional_select(&a.chaincode, &b.chaincode, choice),
+        }
+    }
+}
+
+impl ExtendedPrivateKey {
+    /// Generates a master extended spending key from a provided seed.
+    pub fn generate_master_key(seed: &[u8; 32]) -> CtOption<Self> {
+        let mut mac = HmacSha512::new_from_slice("Cheetah - Master extended key seed".as_bytes())
+            .expect("This instantiation should not fail.");
+        mac.update(seed);
+
+        let result = mac.finalize();
+        let bytes = result.into_bytes();
+
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes[..32]);
+        let key = PrivateKey(Scalar::from_bytes_non_canonical(&array));
+
+        array.copy_from_slice(&bytes[32..]);
+        let chaincode = ChainCode(array);
+
+        CtOption::new(ExtendedPrivateKey { key, chaincode }, !(key.0.is_zero()))
+    }
+
+    /// Derives a private child (either normal or hardened) from the current extended
+    /// private key with the provided index `i`.
+    /// The index, written in little-endian, can represent either a hardened or
+    /// non-hardened child.
+    pub fn derive_private(&self, i: &[u8; 4]) -> CtOption<Self> {
+        ConditionallySelectable::conditional_select(
+            &self.derive_hardened_private(i),
+            &self.derive_normal_private(i),
+            Choice::from(((i[3] & 0b1000_0000) == 0) as u8),
+        )
+    }
+
+    /// Derives a hardened private child from the current extended private key
+    /// with the provided index `i`.
+    /// The index, written in little-endian, must represent an integer greater
+    /// than 2^31.
+    fn derive_hardened_private(&self, i: &[u8; 4]) -> CtOption<Self> {
+        let mut key_array = [0u8; 49];
+        key_array[17..].copy_from_slice(&self.key.to_bytes());
+        let mut mac = HmacSha512::new_from_slice(&self.chaincode.0)
+            .expect("HMAC should take a 32-bytes long chaincode.");
+        mac.update(&key_array);
+        mac.update(i);
+
+        let result = mac.finalize();
+        let bytes = result.into_bytes();
+
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes[..32]);
+        let key = PrivateKey(Scalar::from_bytes_non_canonical(&array) + self.key.0);
+
+        array.copy_from_slice(&bytes[32..]);
+        let chaincode = ChainCode(array);
+
+        CtOption::new(
+            ExtendedPrivateKey { key, chaincode },
+            !(key.0.is_zero())
+                // Make sure that i ≥ 2^31 (i.e. that we derive a hardened child)
+                & Choice::from(((i[3] & 0b1000_0000) != 0) as u8),
+        )
+    }
+
+    /// Derives a non-hardened private child from the current extended private key
+    /// with the provided index `i`.
+    /// The index, written in little-endian, must represent an integer strictly
+    /// smaller than 2^31.
+    fn derive_normal_private(&self, i: &[u8; 4]) -> CtOption<Self> {
+        let public_key_bytes = PublicKey::from_private_key(&self.key).to_bytes();
+
+        let mut mac = HmacSha512::new_from_slice(&self.chaincode.0)
+            .expect("HMAC should take a 32-bytes long chaincode.");
+        mac.update(&public_key_bytes);
+        mac.update(i);
+
+        let result = mac.finalize();
+        let bytes = result.into_bytes();
+
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes[..32]);
+        let key = PrivateKey(Scalar::from_bytes_non_canonical(&array) + self.key.0);
+
+        array.copy_from_slice(&bytes[32..]);
+        let chaincode = ChainCode(array);
+
+        CtOption::new(
+            ExtendedPrivateKey { key, chaincode },
+            !(key.0.is_zero())
+                // Make sure that i < 2^31 (i.e. that we derive a non-hardened child)
+                & Choice::from(((i[3] & 0b1000_0000) == 0) as u8),
+        )
+    }
+
+    /// Derives a public child from the current extended private key with the
+    /// provided index `i`.
+    /// The index, written in little-endian, can represent either a hardened or
+    /// non-hardened child.
+    pub fn derive_public(&self, i: &[u8; 4]) -> CtOption<ExtendedPublicKey> {
+        let derived_private_key = self.derive_private(i);
+        let extended_private_key = derived_private_key.unwrap_or(ExtendedPrivateKey {
+            key: PrivateKey(Scalar::zero()),
+            chaincode: ChainCode([0u8; 32]),
+        });
+
+        CtOption::new(
+            ExtendedPublicKey {
+                key: PublicKey::from_private_key(&extended_private_key.key),
+                chaincode: extended_private_key.chaincode,
+            },
+            derived_private_key.is_some(),
+        )
+    }
+
+    /// Converts this extended private key to an array of bytes
+    pub fn to_bytes(&self) -> [u8; 64] {
+        let mut bytes = [0u8; 64];
+        bytes[0..32].copy_from_slice(&self.key.to_bytes());
+        bytes[32..64].copy_from_slice(&self.chaincode.0);
+
+        bytes
+    }
+
+    /// Constructs an extended private key from an array of bytes
+    pub fn from_bytes(bytes: &[u8; 64]) -> CtOption<Self> {
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes[0..32]);
+        PrivateKey::from_bytes(&array).and_then(|key| {
+            array.copy_from_slice(&bytes[32..64]);
+
+            CtOption::new(
+                ExtendedPrivateKey {
+                    key,
+                    chaincode: ChainCode(array),
+                },
+                !key.0.is_zero(),
+            )
+        })
+    }
+}
+
+/// A wraper combining a derivable public key and a chain code.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+pub struct ExtendedPublicKey {
+    /// A public key
+    pub key: PublicKey,
+    /// A chain code
+    pub chaincode: ChainCode,
+}
+
+impl ConditionallySelectable for ExtendedPublicKey {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        ExtendedPublicKey {
+            key: PublicKey::conditional_select(&a.key, &b.key, choice),
+            chaincode: ChainCode::conditional_select(&a.chaincode, &b.chaincode, choice),
+        }
+    }
+}
+
+impl ExtendedPublicKey {
+    /// Computes the extended public key from a provided extended private key
+    pub fn from_extended_private_key(extended_private_key: &ExtendedPrivateKey) -> Self {
+        ExtendedPublicKey {
+            key: PublicKey::from_private_key(&extended_private_key.key),
+            chaincode: extended_private_key.chaincode,
+        }
+    }
+
+    /// Derives a non-hardened public child from the current extended private key
+    /// with the provided index `i`.
+    /// The index, written in little-endian, must represent an integer strictly
+    /// smaller than 2^31.
+    pub fn derive_normal_public(&self, i: &[u8; 4]) -> CtOption<Self> {
+        let public_key_bytes = self.key.to_bytes();
+
+        let mut mac = HmacSha512::new_from_slice(&self.chaincode.0)
+            .expect("HMAC should take a 32-bytes long chaincode.");
+        mac.update(&public_key_bytes);
+        mac.update(i);
+
+        let result = mac.finalize();
+        let bytes = result.into_bytes();
+
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes[..32]);
+        let point = &BASEPOINT_TABLE * Scalar::from_bytes_non_canonical(&array);
+        let key = PublicKey(point + self.key.0);
+
+        array.copy_from_slice(&bytes[32..]);
+        let chaincode = ChainCode(array);
+
+        CtOption::new(
+            ExtendedPublicKey { key, chaincode },
+            !(point.is_identity())
+                // Make sure that i < 2^31 (i.e. that we derive a non-hardened child)
+                & Choice::from(((i[3] & 0b1000_0000) == 0) as u8),
+        )
+    }
+
+    /// Converts this extended public key to an array of bytes
+    pub fn to_bytes(&self) -> [u8; 81] {
+        let mut bytes = [0u8; 81];
+        bytes[0..49].copy_from_slice(&self.key.to_bytes());
+        bytes[49..81].copy_from_slice(&self.chaincode.0);
+
+        bytes
+    }
+
+    /// Constructs an extended public key from an array of bytes
+    pub fn from_bytes(bytes: &[u8; 81]) -> CtOption<Self> {
+        let mut key_array = [0u8; 49];
+        key_array.copy_from_slice(&bytes[0..49]);
+        PublicKey::from_bytes(&key_array).and_then(|key| {
+            let mut array = [0u8; 32];
+            array.copy_from_slice(&bytes[49..81]);
+
+            CtOption::new(
+                ExtendedPublicKey {
+                    key,
+                    chaincode: ChainCode(array),
+                },
+                !key.0.is_identity(),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cheetah::Scalar;
+    use rand_core::OsRng;
+    use rand_core::RngCore;
+
+    #[test]
+    fn test_extended_private_key_conditional_selection() {
+        let a_skey = PrivateKey(Scalar::one());
+        let a_chaincode = ChainCode([1u8; 32]);
+        let b_skey = PrivateKey(Scalar::from(42u8));
+        let b_chaincode = ChainCode([42u8; 32]);
+
+        let a_ext_skey = ExtendedPrivateKey {
+            key: a_skey,
+            chaincode: a_chaincode,
+        };
+
+        let b_ext_skey = ExtendedPrivateKey {
+            key: b_skey,
+            chaincode: b_chaincode,
+        };
+
+        assert_eq!(
+            ConditionallySelectable::conditional_select(
+                &a_ext_skey,
+                &b_ext_skey,
+                Choice::from(0u8)
+            ),
+            a_ext_skey
+        );
+        assert_eq!(
+            ConditionallySelectable::conditional_select(
+                &a_ext_skey,
+                &b_ext_skey,
+                Choice::from(1u8)
+            ),
+            b_ext_skey
+        );
+    }
+
+    #[test]
+    fn test_extended_public_key_conditional_selection() {
+        let a_skey = PrivateKey(Scalar::one());
+        let a_chaincode = ChainCode([1u8; 32]);
+        let b_skey = PrivateKey(Scalar::from(42u8));
+        let b_chaincode = ChainCode([42u8; 32]);
+
+        let a_ext_skey = ExtendedPrivateKey {
+            key: a_skey,
+            chaincode: a_chaincode,
+        };
+
+        let b_ext_skey = ExtendedPrivateKey {
+            key: b_skey,
+            chaincode: b_chaincode,
+        };
+
+        let a_ext_pkey = ExtendedPublicKey::from_extended_private_key(&a_ext_skey);
+        let b_ext_pkey = ExtendedPublicKey::from_extended_private_key(&b_ext_skey);
+
+        assert_eq!(
+            ConditionallySelectable::conditional_select(
+                &a_ext_pkey,
+                &b_ext_pkey,
+                Choice::from(0u8)
+            ),
+            a_ext_pkey
+        );
+        assert_eq!(
+            ConditionallySelectable::conditional_select(
+                &a_ext_pkey,
+                &b_ext_pkey,
+                Choice::from(1u8)
+            ),
+            b_ext_pkey
+        );
+    }
+
+    #[test]
+    fn test_derive() {
+        let mut rng = OsRng;
+        let mut seed = [0u8; 32];
+        rng.fill_bytes(&mut seed);
+
+        let skey = ExtendedPrivateKey::generate_master_key(&seed).unwrap();
+        let pkey = ExtendedPublicKey::from_extended_private_key(&skey);
+
+        let mut i = [0u8; 4];
+        for _ in 0..100 {
+            rng.fill_bytes(&mut i);
+            // We ensure that children are non-hardened to be able to derive
+            // public children from the extended public key.
+            i[3] &= 0b0111_1111;
+            let skey_child_private = skey.derive_private(&i).unwrap();
+            let skey_child_public = skey.derive_public(&i).unwrap();
+            let pkey_child_public = pkey.derive_normal_public(&i).unwrap();
+
+            assert_eq!(
+                ExtendedPublicKey::from_extended_private_key(&skey_child_private),
+                skey_child_public
+            );
+            assert_eq!(pkey_child_public, skey_child_public);
+        }
+
+        // Derivation of a hardened child should fail for invalid chaincodes
+        {
+            let i = [0xff, 0xff, 0xff, 0x7f]; // 2^31 - 1
+            let skey_child_private = skey.derive_hardened_private(&i);
+            assert!(bool::from(skey_child_private.is_none()));
+        }
+
+        // Derivation of a non-hardened child should fail for invalid chaincodes
+        {
+            let i = [0x00, 0x00, 0x00, 0x80]; // 2^31
+            let skey_child_private = skey.derive_normal_private(&i);
+            assert!(bool::from(skey_child_private.is_none()));
+        }
+
+        // Derivation of a hardened child from a public key should fail
+        {
+            let i = [0x00, 0x00, 0x00, 0x80]; // 2^31
+            let pkey_child_public = pkey.derive_normal_public(&i);
+            assert!(bool::from(pkey_child_public.is_none()));
+        }
+    }
+
+    #[test]
+    fn test_extended_private_key_encoding() {
+        assert_eq!(
+            ExtendedPrivateKey {
+                key: PrivateKey::from_scalar(Scalar::one()),
+                chaincode: ChainCode([1u8; 32])
+            }
+            .to_bytes(),
+            [
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1,
+            ]
+        );
+
+        // Test random keys encodings
+        let mut rng = OsRng;
+
+        let mut chaincode = [0u8; 32];
+        for _ in 0..100 {
+            rng.fill_bytes(&mut chaincode);
+            let key = ExtendedPrivateKey {
+                key: PrivateKey::new(&mut rng),
+                chaincode: ChainCode(chaincode),
+            };
+            let bytes = key.to_bytes();
+
+            assert_eq!(key, ExtendedPrivateKey::from_bytes(&bytes).unwrap());
+        }
+
+        // Test invalid encodings
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+        ];
+        let recovered_key = ExtendedPrivateKey::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
+
+        let bytes = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let recovered_key = ExtendedPrivateKey::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
+    }
+
+    #[test]
+    fn test_extended_public_key_encoding() {
+        assert_eq!(
+            ExtendedPublicKey {
+                key: PublicKey::from_private_key(&PrivateKey::from_scalar(Scalar::zero())),
+                chaincode: ChainCode([1u8; 32])
+            }
+            .to_bytes(),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            ]
+        );
+
+        // Test random keys encodings
+        let mut rng = OsRng;
+
+        let mut chaincode = [0u8; 32];
+        for _ in 0..100 {
+            rng.fill_bytes(&mut chaincode);
+            let key = ExtendedPublicKey {
+                key: PublicKey::from_private_key(&PrivateKey::new(&mut rng)),
+                chaincode: ChainCode(chaincode),
+            };
+            let bytes = key.to_bytes();
+
+            assert_eq!(key, ExtendedPublicKey::from_bytes(&bytes).unwrap());
+        }
+
+        // Test invalid encodings
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let recovered_key = ExtendedPublicKey::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
+
+        let bytes = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let recovered_key = ExtendedPublicKey::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
+    }
+
+    #[test]
+    #[cfg(feature = "serialize")]
+    fn test_extended_private_key_serde() {
+        let mut rng = OsRng;
+        let skey = PrivateKey::new(&mut rng);
+        let chaincode = ChainCode([1u8; 32]);
+
+        let ext_skey = ExtendedPrivateKey {
+            key: skey,
+            chaincode,
+        };
+
+        let mut encoded = bincode::serialize(&ext_skey).unwrap();
+        let parsed: ExtendedPrivateKey = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(parsed, ext_skey);
+
+        // Check that the encoding is 64 bytes exactly
+        assert_eq!(encoded.len(), 64);
+
+        // Check that the encoding itself matches the usual one
+        assert_eq!(
+            ext_skey,
+            bincode::deserialize(&ext_skey.to_bytes()).unwrap()
+        );
+
+        // Check that invalid encodings fail
+        encoded[31] = 255;
+        assert!(bincode::deserialize::<ExtendedPrivateKey>(&encoded).is_err());
+
+        let encoded = bincode::serialize(&ext_skey).unwrap();
+        assert!(bincode::deserialize::<ExtendedPrivateKey>(&encoded[0..63]).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "serialize")]
+    fn test_extended_public_key_serde() {
+        let mut rng = OsRng;
+        let skey = PrivateKey::new(&mut rng);
+        let chaincode = ChainCode([1u8; 32]);
+
+        let ext_skey = ExtendedPrivateKey {
+            key: skey,
+            chaincode,
+        };
+
+        let ext_pkey = ExtendedPublicKey::from_extended_private_key(&ext_skey);
+
+        let mut encoded = bincode::serialize(&ext_pkey).unwrap();
+        let parsed: ExtendedPublicKey = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(parsed, ext_pkey);
+
+        // Check that the encoding is 81 bytes exactly
+        assert_eq!(encoded.len(), 81);
+
+        // Check that the encoding itself matches the usual one
+        assert_eq!(
+            ext_skey,
+            bincode::deserialize(&ext_skey.to_bytes()).unwrap()
+        );
+
+        // Check that invalid encodings fail
+        encoded[48] = 255;
+        assert!(bincode::deserialize::<ExtendedPublicKey>(&encoded).is_err());
+
+        let encoded = bincode::serialize(&ext_pkey).unwrap();
+        assert!(bincode::deserialize::<ExtendedPublicKey>(&encoded[0..80]).is_err());
+    }
+}

--- a/src/derivation.rs
+++ b/src/derivation.rs
@@ -22,11 +22,14 @@ use serde::{Deserialize, Serialize};
 
 type HmacSha512 = Hmac<Sha512>;
 
+/// Chain code length, could be only 16 but set to 32 for safety.
+pub const CHAIN_CODE_LENGTH: usize = 32;
+
 /// BIP32 like chain codes, providing large entropy when deriving keys.
 /// Chain codes are 32 bytes long.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-pub struct ChainCode([u8; 32]);
+pub struct ChainCode([u8; CHAIN_CODE_LENGTH]);
 
 impl ConditionallySelectable for ChainCode {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {

--- a/src/derivation.rs
+++ b/src/derivation.rs
@@ -128,7 +128,7 @@ impl ExtendedPrivateKey {
     /// The index, written in little-endian, must represent an integer strictly
     /// smaller than 2^31.
     fn derive_normal_private(&self, i: &[u8; 4]) -> CtOption<Self> {
-        let public_key_bytes = PublicKey::from_private_key(&self.key).to_bytes();
+        let public_key_bytes = PublicKey::from(&self.key).to_bytes();
 
         let mut mac = HmacSha512::new_from_slice(&self.chaincode.0)
             .expect("HMAC should take a 32-bytes long chaincode.");
@@ -166,7 +166,7 @@ impl ExtendedPrivateKey {
 
         CtOption::new(
             ExtendedPublicKey {
-                key: PublicKey::from_private_key(&extended_private_key.key),
+                key: PublicKey::from(&extended_private_key.key),
                 chaincode: extended_private_key.chaincode,
             },
             derived_private_key.is_some(),
@@ -223,7 +223,7 @@ impl ExtendedPublicKey {
     /// Computes the extended public key from a provided extended private key
     pub fn from_extended_private_key(extended_private_key: &ExtendedPrivateKey) -> Self {
         ExtendedPublicKey {
-            key: PublicKey::from_private_key(&extended_private_key.key),
+            key: PublicKey::from(&extended_private_key.key),
             chaincode: extended_private_key.chaincode,
         }
     }
@@ -468,7 +468,7 @@ mod tests {
     fn test_extended_public_key_encoding() {
         assert_eq!(
             ExtendedPublicKey {
-                key: PublicKey::from_private_key(&PrivateKey::from_scalar(Scalar::zero())),
+                key: PublicKey::from(&PrivateKey::from_scalar(Scalar::zero())),
                 chaincode: ChainCode([1u8; CHAIN_CODE_LENGTH])
             }
             .to_bytes(),
@@ -486,7 +486,7 @@ mod tests {
         for _ in 0..100 {
             rng.fill_bytes(&mut chaincode);
             let key = ExtendedPublicKey {
-                key: PublicKey::from_private_key(&PrivateKey::new(&mut rng)),
+                key: PublicKey::from(&PrivateKey::new(&mut rng)),
                 chaincode: ChainCode(chaincode),
             };
             let bytes = key.to_bytes();

--- a/src/derivation.rs
+++ b/src/derivation.rs
@@ -246,7 +246,7 @@ impl ExtendedPublicKey {
         let mut array = [0u8; 32];
         array.copy_from_slice(&bytes[..32]);
         let point = &BASEPOINT_TABLE * Scalar::from_bytes_non_canonical(&array);
-        let key = PublicKey(point + self.key.0);
+        let key = PublicKey((point + self.key.0).into());
 
         array.copy_from_slice(&bytes[32..]);
         let chaincode = ChainCode(array);

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ impl Display for SignatureError {
 #[cfg(test)]
 mod tests {
     use crate::{PrivateKey, PublicKey};
-    use cheetah::{Fp, Fp6, ProjectivePoint};
+    use cheetah::{AffinePoint, Fp, Fp6};
     use rand_core::OsRng;
 
     #[test]
@@ -44,7 +44,7 @@ mod tests {
         let pkey = PublicKey::from_private_key(&skey);
         let signature = skey.sign(&[Fp::zero()], &mut rng);
 
-        let wrong_pkey = PublicKey(ProjectivePoint::from_raw_coordinates([
+        let wrong_pkey = PublicKey(AffinePoint::from_raw_coordinates([
             Fp6::from_raw_unchecked([
                 0x9bfcd3244afcb637,
                 0x39005e478830b187,
@@ -61,7 +61,6 @@ mod tests {
                 0xa92531e4b1338285,
                 0x5b8157814141a7a7,
             ]),
-            Fp6::one(),
         ]));
 
         assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,3 +29,60 @@ impl Display for SignatureError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{PrivateKey, PublicKey};
+    use cheetah::{Fp, Fp6, ProjectivePoint};
+    use rand_core::OsRng;
+
+    #[test]
+    fn test_debug() {
+        let mut rng = OsRng;
+
+        let skey = PrivateKey::new(&mut rng);
+        let pkey = PublicKey::from_private_key(&skey);
+        let signature = skey.sign(&[Fp::zero()], &mut rng);
+
+        let wrong_pkey = PublicKey(ProjectivePoint::from_raw_coordinates([
+            Fp6::from_raw_unchecked([
+                0x9bfcd3244afcb637,
+                0x39005e478830b187,
+                0x7046f1c03b42c6cc,
+                0xb5eeac99193711e5,
+                0x7fd272e724307b98,
+                0xcc371dd6dd5d8625,
+            ]),
+            Fp6::from_raw_unchecked([
+                0x9d03fdc216dfaae8,
+                0xbf4ade2a7665d9b8,
+                0xf08b022d5b3262b7,
+                0x2eaf583a3cf15c6f,
+                0xa92531e4b1338285,
+                0x5b8157814141a7a7,
+            ]),
+            Fp6::one(),
+        ]));
+
+        assert_eq!(
+            format!("{:?}", signature.verify(&[Fp::zero()], &wrong_pkey)),
+            "Err(InvalidPublicKey)"
+        );
+        assert_eq!(
+            format!("{:?}", signature.verify(&[Fp::one()], &pkey)),
+            "Err(InvalidSignature)"
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                signature.verify(&[Fp::zero()], &wrong_pkey).unwrap_err()
+            ),
+            "The public key is not an element of the prime subgroup."
+        );
+        assert_eq!(
+            format!("{}", signature.verify(&[Fp::one()], &pkey).unwrap_err()),
+            "The signature is invalid or was incorrectly computed."
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ mod tests {
         let mut rng = OsRng;
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(&skey);
+        let pkey = PublicKey::from(&skey);
         let signature = skey.sign(&[Fp::zero()], &mut rng);
 
         let wrong_pkey = PublicKey(AffinePoint::from_raw_coordinates([

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -181,6 +181,9 @@ mod tests {
 
         let signature = key_pair.sign(&message, &mut rng);
         assert!(key_pair.verify_signature(&signature, &message).is_ok());
+
+        let keyed_signature = key_pair.sign_and_bind_pkey(&message, &mut rng);
+        assert!(keyed_signature.verify(&message).is_ok());
     }
 
     #[test]
@@ -201,7 +204,7 @@ mod tests {
             ]
         );
 
-        // Test random key pairs encoding
+        // Test random key pairs encodings
         let mut rng = OsRng;
 
         for _ in 0..100 {
@@ -210,6 +213,22 @@ mod tests {
 
             assert_eq!(key_pair, KeyPair::from_bytes(&bytes).unwrap());
         }
+
+        // Test invalid encodings
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
+        let recovered_key = KeyPair::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
+
+        let bytes = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+        ];
+        let recovered_key = KeyPair::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! let mut rng = OsRng;
 //! let message = [Fp::one(); 42];
 //! let skey = PrivateKey::new(&mut rng);
-//! let pkey = PublicKey::from_private_key(&skey);
+//! let pkey = PublicKey::from(&skey);
 //!
 //! let signature = Signature::sign_with_provided_pkey(&message, &skey, &pkey, &mut rng);
 //! ```
@@ -112,7 +112,7 @@
 //! let mut rng = OsRng;
 //! let message = [Fp::one(); 42];
 //! let skey = PrivateKey::new(&mut rng);
-//! let pkey = PublicKey::from_private_key(&skey);
+//! let pkey = PublicKey::from(&skey);
 //!
 //! let signature = skey.sign(&message, &mut rng);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,6 @@ pub use public::PublicKey;
 
 pub use keypair::KeyPair;
 
-pub use derivation::{ExtendedPrivateKey, ExtendedPublicKey};
+pub use derivation::{ChainCode, ExtendedPrivateKey, ExtendedPublicKey, CHAIN_CODE_LENGTH};
 
 pub use signature::{KeyedSignature, Signature};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,8 @@
 #[macro_use]
 extern crate std;
 
+mod constants;
+
 mod error;
 
 /// The private key module.
@@ -188,11 +190,13 @@ mod derivation;
 /// The Schnorr signature module.
 mod signature;
 
+pub use constants::*;
+
 pub use private::PrivateKey;
 pub use public::PublicKey;
 
 pub use keypair::KeyPair;
 
-pub use derivation::{ChainCode, ExtendedPrivateKey, ExtendedPublicKey, CHAIN_CODE_LENGTH};
+pub use derivation::{ChainCode, ExtendedPrivateKey, ExtendedPublicKey};
 
 pub use signature::{KeyedSignature, Signature};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,9 @@ mod public;
 /// The key pair module.
 mod keypair;
 
+/// The key derivation module.
+mod derivation;
+
 /// The Schnorr signature module.
 mod signature;
 
@@ -189,5 +192,7 @@ pub use private::PrivateKey;
 pub use public::PublicKey;
 
 pub use keypair::KeyPair;
+
+pub use derivation::{ExtendedPrivateKey, ExtendedPublicKey};
 
 pub use signature::{KeyedSignature, Signature};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,10 @@
 #![deny(unsafe_code)]
 #![no_std]
 
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 mod error;
 
 /// The private key module.

--- a/src/private.rs
+++ b/src/private.rs
@@ -19,7 +19,7 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 use serde::{Deserialize, Serialize};
 
 /// A private key
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 pub struct PrivateKey(pub(crate) Scalar);
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -9,6 +9,7 @@
 //! This module provides a `PrivateKey` wrapping
 //! struct around a `Scalar` element.
 
+use super::PRIVATE_KEY_LENGTH;
 use super::{KeyedSignature, Signature};
 
 use cheetah::{Fp, Scalar};
@@ -51,12 +52,12 @@ impl PrivateKey {
     }
 
     /// Converts this private key to an array of bytes
-    pub fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> [u8; PRIVATE_KEY_LENGTH] {
         self.0.to_bytes()
     }
 
     /// Constructs a private key from an array of bytes
-    pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
+    pub fn from_bytes(bytes: &[u8; PRIVATE_KEY_LENGTH]) -> CtOption<Self> {
         Scalar::from_bytes(bytes).and_then(|s| CtOption::new(PrivateKey(s), !s.is_zero()))
     }
 
@@ -174,8 +175,8 @@ mod tests {
         let parsed: PrivateKey = bincode::deserialize(&encoded).unwrap();
         assert_eq!(parsed, skey);
 
-        // Check that the encoding is 32 bytes exactly
-        assert_eq!(encoded.len(), 32);
+        // Check that the encoding is PRIVATE_KEY_LENGTH (32) bytes exactly
+        assert_eq!(encoded.len(), PRIVATE_KEY_LENGTH);
 
         // Check that the encoding itself matches the usual one
         assert_eq!(skey, bincode::deserialize(&skey.to_bytes()).unwrap());

--- a/src/private.rs
+++ b/src/private.rs
@@ -32,7 +32,11 @@ impl ConditionallySelectable for PrivateKey {
 impl PrivateKey {
     /// Generates a new random private key
     pub fn new(mut rng: impl CryptoRng + RngCore) -> Self {
-        let secret_scalar = Scalar::random(&mut rng);
+        let mut secret_scalar = Scalar::random(&mut rng);
+        // This should not happen, but we never know..
+        while bool::from(secret_scalar.is_zero()) {
+            secret_scalar = Scalar::random(&mut rng);
+        }
 
         PrivateKey(secret_scalar)
     }
@@ -53,7 +57,7 @@ impl PrivateKey {
 
     /// Constructs a private key from an array of bytes
     pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        Scalar::from_bytes(bytes).and_then(|s| CtOption::new(PrivateKey(s), Choice::from(1u8)))
+        Scalar::from_bytes(bytes).and_then(|s| CtOption::new(PrivateKey(s), !s.is_zero()))
     }
 
     /// Computes a Schnorr signature.
@@ -83,6 +87,21 @@ mod tests {
     use crate::PublicKey;
 
     #[test]
+    fn test_conditional_selection() {
+        let a = PrivateKey(Scalar::from(10u8));
+        let b = PrivateKey(Scalar::from(42u8));
+
+        assert_eq!(
+            ConditionallySelectable::conditional_select(&a, &b, Choice::from(0u8)),
+            a
+        );
+        assert_eq!(
+            ConditionallySelectable::conditional_select(&a, &b, Choice::from(1u8)),
+            b
+        );
+    }
+
+    #[test]
     fn test_signature() {
         let mut rng = OsRng;
 
@@ -96,6 +115,9 @@ mod tests {
 
         let signature = skey.sign(&message, &mut rng);
         assert!(signature.verify(&message, &pkey).is_ok());
+
+        let keyed_signature = skey.sign_and_bind_pkey(&message, &mut rng);
+        assert!(keyed_signature.verify(&message).is_ok());
     }
 
     #[test]
@@ -116,7 +138,7 @@ mod tests {
             ]
         );
 
-        // Test random keys encoding
+        // Test random keys encodings
         let mut rng = OsRng;
 
         for _ in 0..100 {
@@ -126,14 +148,21 @@ mod tests {
             assert_eq!(key, PrivateKey::from_bytes(&bytes).unwrap());
         }
 
-        // Test invalid encoding
+        // Test invalid encodings
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
+        let recovered_key = PrivateKey::from_bytes(&bytes);
+        assert!(bool::from(recovered_key.is_none()));
+
         let bytes = [
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
             0xff, 0xff, 0xff, 0xff,
         ];
         let recovered_key = PrivateKey::from_bytes(&bytes);
-        assert!(bool::from(recovered_key.is_none()))
+        assert!(bool::from(recovered_key.is_none()));
     }
 
     #[test]

--- a/src/private.rs
+++ b/src/private.rs
@@ -10,7 +10,7 @@
 //! struct around a `Scalar` element.
 
 use super::PRIVATE_KEY_LENGTH;
-use super::{KeyedSignature, Signature};
+use super::{KeyPair, KeyedSignature, Signature};
 
 use cheetah::{Fp, Scalar};
 use rand_core::{CryptoRng, RngCore};
@@ -23,6 +23,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 pub struct PrivateKey(pub(crate) Scalar);
+
+impl From<&KeyPair> for PrivateKey {
+    /// Extracts a private key from a key pair reference.
+    fn from(key_pair: &KeyPair) -> PrivateKey {
+        key_pair.private_key
+    }
+}
+
+impl From<KeyPair> for PrivateKey {
+    /// Extracts a private key from a key pair.
+    fn from(key_pair: KeyPair) -> PrivateKey {
+        key_pair.private_key
+    }
+}
 
 impl ConditionallySelectable for PrivateKey {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
@@ -112,7 +126,7 @@ mod tests {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(&skey);
+        let pkey = PublicKey::from(&skey);
 
         let signature = skey.sign(&message, &mut rng);
         assert!(signature.verify(&message, &pkey).is_ok());

--- a/src/public.rs
+++ b/src/public.rs
@@ -10,6 +10,7 @@
 //! struct around an `AffinePoint` element.
 
 use super::error::SignatureError;
+use super::PUBLIC_KEY_LENGTH;
 use super::{PrivateKey, Signature};
 
 use cheetah::{AffinePoint, CompressedPoint, Fp, BASEPOINT_TABLE};
@@ -38,12 +39,12 @@ impl PublicKey {
     }
 
     /// Converts this public key to an array of bytes
-    pub fn to_bytes(&self) -> [u8; 49] {
+    pub fn to_bytes(&self) -> [u8; PUBLIC_KEY_LENGTH] {
         self.0.to_compressed().to_bytes()
     }
 
     /// Constructs a public key from an array of bytes
-    pub fn from_bytes(bytes: &[u8; 49]) -> CtOption<Self> {
+    pub fn from_bytes(bytes: &[u8; PUBLIC_KEY_LENGTH]) -> CtOption<Self> {
         AffinePoint::from_compressed(&CompressedPoint::from_bytes(bytes)).map(PublicKey)
     }
 
@@ -141,8 +142,8 @@ mod tests {
         let parsed: PublicKey = bincode::deserialize(&encoded).unwrap();
         assert_eq!(parsed, pkey);
 
-        // Check that the encoding is 49 bytes exactly
-        assert_eq!(encoded.len(), 49);
+        // Check that the encoding is PUBLIC_KEY_LENGTH (49) bytes exactly
+        assert_eq!(encoded.len(), PUBLIC_KEY_LENGTH);
 
         // Check that the encoding itself matches the usual one
         assert_eq!(pkey, bincode::deserialize(&pkey.to_bytes()).unwrap());

--- a/src/public.rs
+++ b/src/public.rs
@@ -64,6 +64,21 @@ mod tests {
     use rand_core::OsRng;
 
     #[test]
+    fn test_conditional_selection() {
+        let a = PublicKey(ProjectivePoint::identity());
+        let b = PublicKey(ProjectivePoint::generator());
+
+        assert_eq!(
+            ConditionallySelectable::conditional_select(&a, &b, Choice::from(0u8)),
+            a
+        );
+        assert_eq!(
+            ConditionallySelectable::conditional_select(&a, &b, Choice::from(1u8)),
+            b
+        );
+    }
+
+    #[test]
     fn test_signature() {
         let mut rng = OsRng;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -53,11 +53,7 @@ impl Signature {
         let r = Scalar::random(&mut rng);
         let r_point = AffinePoint::from(&BASEPOINT_TABLE * r);
 
-        let h = hash_message(
-            &r_point.get_x(),
-            &PublicKey::from_private_key(skey),
-            message,
-        );
+        let h = hash_message(&r_point.get_x(), &PublicKey::from(skey), message);
         let h_bits = h.as_bits::<Lsb0>();
 
         // Reconstruct a scalar from the binary sequence of h
@@ -183,7 +179,7 @@ impl KeyedSignature {
     /// the provided `PrivateKey` internally. For a faster signing, one should prefer
     /// to use `Signature::sign_with_provided_pkey` or `Signature::sign_with_keypair`.
     pub fn sign(message: &[Fp], skey: &PrivateKey, mut rng: impl CryptoRng + RngCore) -> Self {
-        let public_key = PublicKey::from_private_key(skey);
+        let public_key = PublicKey::from(skey);
         let r = Scalar::random(&mut rng);
         let r_point = AffinePoint::from(&BASEPOINT_TABLE * r);
 
@@ -357,7 +353,7 @@ mod test {
         }
 
         let skey = PrivateKey::new(&mut rng);
-        let pkey = PublicKey::from_private_key(&skey);
+        let pkey = PublicKey::from(&skey);
 
         let signature = Signature::sign(&message, &skey, &mut rng);
 
@@ -531,7 +527,7 @@ mod test {
         }
 
         let keyed_signature = KeyedSignature {
-            public_key: PublicKey::from_private_key(&skey),
+            public_key: PublicKey::from(&skey),
             signature,
         };
         {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -293,6 +293,26 @@ mod test {
     use rand_core::OsRng;
 
     #[test]
+    fn test_conditional_selection() {
+        let mut rng = OsRng;
+        let a = PrivateKey::new(&mut rng);
+        let b = PrivateKey::new(&mut rng);
+
+        let message = [Fp::one(); 3];
+        let sig_a = a.sign(&message, &mut rng);
+        let sig_b = b.sign(&message, &mut rng);
+
+        assert_eq!(
+            ConditionallySelectable::conditional_select(&sig_a, &sig_b, Choice::from(0u8)),
+            sig_a
+        );
+        assert_eq!(
+            ConditionallySelectable::conditional_select(&sig_a, &sig_b, Choice::from(1u8)),
+            sig_b
+        );
+    }
+
+    #[test]
     fn test_signature() {
         let mut rng = OsRng;
 
@@ -350,6 +370,30 @@ mod test {
 
         {
             let wrong_pkey = PublicKey(ProjectivePoint::generator());
+            assert!(signature.verify(&message, &wrong_pkey).is_err());
+        }
+
+        {
+            // Small order public key
+            let wrong_pkey = PublicKey(ProjectivePoint::from_raw_coordinates([
+                Fp6::from_raw_unchecked([
+                    0x9bfcd3244afcb637,
+                    0x39005e478830b187,
+                    0x7046f1c03b42c6cc,
+                    0xb5eeac99193711e5,
+                    0x7fd272e724307b98,
+                    0xcc371dd6dd5d8625,
+                ]),
+                Fp6::from_raw_unchecked([
+                    0x9d03fdc216dfaae8,
+                    0xbf4ade2a7665d9b8,
+                    0xf08b022d5b3262b7,
+                    0x2eaf583a3cf15c6f,
+                    0xa92531e4b1338285,
+                    0x5b8157814141a7a7,
+                ]),
+                Fp6::one(),
+            ]));
             assert!(signature.verify(&message, &wrong_pkey).is_err());
         }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -14,7 +14,7 @@ use super::{KeyPair, PrivateKey, PublicKey};
 
 use bitvec::{order::Lsb0, view::AsBits};
 use cheetah::BASEPOINT_TABLE;
-use cheetah::{AffinePoint, CompressedPoint, Fp, Fp6, ProjectivePoint, Scalar};
+use cheetah::{AffinePoint, Fp, Fp6, ProjectivePoint, Scalar};
 use hash::{
     rescue_64_8_4::RescueHash,
     traits::{Digest, Hasher},
@@ -243,7 +243,7 @@ impl KeyedSignature {
     /// Converts this signature to an array of bytes
     pub fn to_bytes(&self) -> [u8; 129] {
         let mut output = [0u8; 129];
-        output[0..49].copy_from_slice(&self.public_key.to_bytes().0);
+        output[0..49].copy_from_slice(&self.public_key.to_bytes());
         output[49..129].copy_from_slice(&self.signature.to_bytes());
 
         output
@@ -253,7 +253,7 @@ impl KeyedSignature {
     pub fn from_bytes(bytes: &[u8; 129]) -> CtOption<Self> {
         let mut array = [0u8; 49];
         array.copy_from_slice(&bytes[0..49]);
-        let public_key = PublicKey::from_bytes(&CompressedPoint(array));
+        let public_key = PublicKey::from_bytes(&array);
 
         let mut array = [0u8; 80];
         array.copy_from_slice(&bytes[49..129]);


### PR DESCRIPTION
This PR introduced key derivation following BIP32 specification.
It also adds a check on private key generation.
To prevent issue in signature verification when hashing public keys, the backend type has been changed to `AffinePoint`, for unicity.