### PR TITLE
Batch verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,23 @@ This crate provides an implementation of a modified version of the Schnorr signa
 The underlying curve is a custom curve, Cheetah, based on a sextic extension of the the Prime Field Fp with p = 2<sup>64</sup> - 2<sup>32</sup> + 1, and curve equation E(Fp): y<sup>2</sup> = x<sup>3</sup> + x + B, with
 B = `u + 395`
 where
+
 - `u^6 - 7 = 0` is the polynomial defining the sextic extension Fp6 over Fp.
 and implemented [here](https://github.com/ToposWare/cheetah).
 
-* This implementation may not rely on the Rust standard library by relyong on the `alloc` crate instead.
+- This implementation may not rely on the Rust standard library by relying on the `alloc` crate instead.
 
 **WARNING:** This is an ongoing, prototype implementation subject to changes. In particular, it has not been audited and may contain bugs and security flaws. This implementation is NOT ready for production use.
 
-
 ## Features
 
-* `serialize` (on by default): Enables Serde serialization
-* `std` (on by default): Enables the Rust standard library
+- `serialize` (on by default): Enables Serde serialization
+- `std` (on by default): Enables the Rust standard library
 
 ## Description
 
 See :
+
 - [here](https://en.wikipedia.org/wiki/Schnorr_signature) for an introduction to Schnorr signatures,
 - [here](https://github.com/ToposWare/cheetah) for the implementation of the underlying fields and elliptic curve,
 - [here](https://github.com/ToposWare/hash) for the implementation of the internal Rescue hash function.
@@ -28,7 +29,7 @@ See :
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -23,7 +23,7 @@ use bitvec::{order::Lsb0, view::AsBits};
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::vec::Vec;
 
 /// Verifies a batch of signatures with their associated public_keys
 pub fn verify_batch(

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -162,12 +162,12 @@ mod test {
         let mut keypairs: Vec<KeyPair> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
 
-        for i in 0..messages.len() {
+        for (i, message) in messages.iter().enumerate() {
             let mut keypair: KeyPair = KeyPair::new(&mut rng);
             if i == 3 || i == 4 {
-                keypair = keypairs[0].clone();
+                keypair = keypairs[0];
             }
-            signatures.push(keypair.sign(messages[i], rng));
+            signatures.push(keypair.sign(message, rng));
             keypairs.push(keypair);
         }
         let mut public_keys: Vec<PublicKey> = keypairs.iter().map(|key| key.public_key).collect();

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,174 @@
+// Copyright (c) 2021-2022 Toposware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module provides an implementation of batched signature
+//! verification and an implementation of "Non-interactive
+//! half-aggregation of EdDSA and variants of Schnorr signatures".
+
+use cheetah::AffinePoint;
+use cheetah::Fp6;
+use cheetah::Scalar;
+use cheetah::BASEPOINT_TABLE;
+
+use super::error::SignatureError;
+use super::signature::hash_message;
+use super::{PublicKey, Signature};
+
+use bitvec::{order::Lsb0, view::AsBits};
+use rand_core::{CryptoRng, RngCore};
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, vec::Vec};
+
+/// Verifies a batch of signatures with their associated public_keys
+pub fn verify_batch(
+    signatures: &[Signature],
+    public_keys: &[PublicKey],
+    messages: &[&[u8]],
+    mut rng: impl CryptoRng + RngCore,
+) -> Result<(), SignatureError> {
+    assert!(
+        signatures.len() == public_keys.len(),
+        "We should have the same number of signatures than public keys"
+    );
+    assert!(
+        messages.len() == public_keys.len(),
+        "We should have the same number of messages than public keys"
+    );
+
+    let (scalars, hashes) =
+        generate_batch_coefficients(signatures, public_keys, messages, &mut rng);
+
+    verify_prepared_batch(scalars, hashes, signatures, public_keys)
+}
+
+/// Prepares a batch verification of Schnorr signatures
+/// It computes the random challenges for each signature and the random scalars to
+/// scale the public keys.
+#[allow(non_snake_case)]
+fn generate_batch_coefficients(
+    signatures: &[Signature],
+    public_keys: &[PublicKey],
+    messages: &[&[u8]],
+    mut rng: impl CryptoRng + RngCore,
+) -> (Vec<Scalar>, Vec<Scalar>) {
+    let hashes: Vec<Scalar> = signatures
+        .iter()
+        .zip(public_keys)
+        .zip(messages)
+        .map(|((s, k), m)| {
+            let x_felt = Fp6::from_bytes(&s.x.0[0..48].try_into().unwrap()).unwrap();
+            let h = hash_message(&x_felt, k, m);
+            let h_bits = h.as_bits::<Lsb0>();
+
+            Scalar::from_bits_vartime(h_bits)
+        })
+        .collect();
+
+    let scalars: Vec<Scalar> = signatures
+        .iter()
+        .map(|_| Scalar::random(&mut rng))
+        .collect();
+
+    (scalars, hashes)
+}
+
+/// Verifies a batch with a set of random scalars and hash outputs
+fn verify_prepared_batch(
+    scalars: Vec<Scalar>,
+    mut hashes: Vec<Scalar>,
+    signatures: &[Signature],
+    public_keys: &[PublicKey],
+) -> Result<(), SignatureError> {
+    // Compute the linear combination of the random scalars with the
+    // signatures. This is used to multiply the curve basepoint.
+    let lin_comb: Scalar = signatures
+        .iter()
+        .map(|sig| sig.e)
+        .zip(scalars.iter())
+        .map(|(e, s)| s * e)
+        .sum();
+    let scaled_basepoint = BASEPOINT_TABLE.multiply_vartime(&lin_comb.to_bytes());
+
+    let points: Vec<AffinePoint> = signatures
+        .iter()
+        .map(|sig| AffinePoint::from_compressed(&sig.x).unwrap())
+        .collect();
+
+    // Multiply each hash by the random value
+    for (h, s) in hashes.iter_mut().zip(scalars.iter()) {
+        *h = &*h * s;
+    }
+    let key_points: Vec<AffinePoint> = public_keys.into_iter().map(|k| k.0).collect();
+
+    // Convert scalars and hash outputs to byte slices
+    let scalar_bytes: Vec<[u8; 32]> = scalars.into_iter().map(|s| s.to_bytes()).collect();
+    let hashes_bytes: Vec<[u8; 32]> = hashes.into_iter().map(|h| h.to_bytes()).collect();
+
+    // Compute the multi-scalar multiplication on both side of the equation
+    let left = AffinePoint::multiply_many_vartime(&points, &scalar_bytes);
+    let right = AffinePoint::multiply_many_vartime(&key_points, &hashes_bytes);
+    // Add to the sum of keys the scaled basepoint computed earlier
+    let right = AffinePoint::from(scaled_basepoint.add_mixed_unchecked(&right));
+
+    if left.get_x() == right.get_x() {
+        Ok(())
+    } else {
+        Err(SignatureError::InvalidSignature)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::KeyPair;
+    use rand_core::OsRng;
+
+    #[test]
+    fn verify_one_signature() {
+        let mut rng = OsRng;
+        let message = b"Message1";
+
+        let keypair: KeyPair = KeyPair::new(&mut rng);
+        let signature = keypair.sign(message, rng);
+        let public_key = keypair.public_key;
+
+        assert!(public_key.verify_signature(&signature, message).is_ok());
+        assert!(verify_batch(&[signature], &[public_key], &[message], &mut rng).is_ok());
+        assert!(verify_batch(&[signature], &[public_key], &[message], &mut rng).is_ok());
+    }
+
+    #[test]
+    fn verify_five_signatures() {
+        let mut rng = OsRng;
+        let messages: [&[u8]; 5] = [
+            b"Message1",
+            b"Message2",
+            b"Message3",
+            b"Message4",
+            b"Message5",
+        ];
+        let mut keypairs: Vec<KeyPair> = Vec::new();
+        let mut signatures: Vec<Signature> = Vec::new();
+
+        for i in 0..messages.len() {
+            let mut keypair: KeyPair = KeyPair::new(&mut rng);
+            if i == 3 || i == 4 {
+                keypair = keypairs[0].clone();
+            }
+            signatures.push(keypair.sign(messages[i], rng));
+            keypairs.push(keypair);
+        }
+        let mut public_keys: Vec<PublicKey> = keypairs.iter().map(|key| key.public_key).collect();
+
+        assert!(verify_batch(&signatures[..], &public_keys[..], &messages[..], &mut rng).is_ok());
+
+        public_keys.swap(1, 2);
+        assert!(verify_batch(&signatures[..], &public_keys[..], &messages[..], &mut rng).is_err());
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,7 +24,7 @@ pub const PUBLIC_KEY_LENGTH: usize = BASEFIELD_LENGTH + 1;
 pub const KEY_PAIR_LENGTH: usize = PRIVATE_KEY_LENGTH;
 
 /// Signature length in bytes (serialized form)
-pub const SIGNATURE_LENGTH: usize = BASEFIELD_LENGTH + SCALAR_LENGTH;
+pub const SIGNATURE_LENGTH: usize = BASEFIELD_LENGTH + 1 + SCALAR_LENGTH;
 
 /// Keyed signature length in bytes (serialized form)
 pub const KEYED_SIGNATURE_LENGTH: usize = SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,23 @@
 //! assert!(pkey.verify_signature(&signature, &message).is_ok());
 //! ```
 //!
+//! Signatures can be verified in a batch, which improves the amortized
+//! verification cost per signature. The order of the provided messages,
+//! public keys and signatures ***matters*** and needs to be kept
+//! consistent. You can verify a batch of signatures as illustrated in
+//! the following example:
+//!
+//! ```rust,ignore
+//! use schnorr_sig::verify_batch;
+//! use rand_core::OsRng;
+//!
+//! let mut rng = OsRng;
+//!
+//! // Sign a bunch of messages with (potentially different) private keys.
+//!
+//! assert!(verify_batch(&signatures, &public_keys, &messages, &mut rng).is_ok());
+//! ```
+//!
 //! The `KeyedSignature` struct can also be used to attach the identity
 //! of the signer (its `PublicKey`) to a produced signature. The
 //! `KeyedSignature` struct shares the same signing methods than the
@@ -193,6 +210,8 @@ mod derivation;
 /// The Schnorr signature module.
 mod signature;
 
+mod batch;
+
 pub use constants::*;
 
 pub use error::SignatureError;
@@ -205,3 +224,5 @@ pub use keypair::KeyPair;
 pub use derivation::{ChainCode, ExtendedPrivateKey, ExtendedPublicKey};
 
 pub use signature::{KeyedSignature, Signature};
+
+pub use batch::verify_batch;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -19,7 +19,7 @@ use bitvec::{order::Lsb0, view::AsBits};
 use cheetah::BASEPOINT_TABLE;
 use cheetah::{AffinePoint, CompressedPoint, Fp, Fp6, Scalar};
 use hash::{
-    rescue_64_8_4::RescueHash,
+    rescue_64_12_8::RescueHash,
     traits::{Digest, Hasher},
 };
 use rand_core::{CryptoRng, RngCore};

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -17,7 +17,7 @@ use super::{BASEFIELD_LENGTH, KEYED_SIGNATURE_LENGTH, SCALAR_LENGTH, SIGNATURE_L
 
 use bitvec::{order::Lsb0, view::AsBits};
 use cheetah::BASEPOINT_TABLE;
-use cheetah::{AffinePoint, Fp, Fp6, Scalar};
+use cheetah::{AffinePoint, CompressedPoint, Fp, Fp6, Scalar};
 use hash::{
     rescue_64_8_4::RescueHash,
     traits::{Digest, Hasher},
@@ -32,8 +32,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 pub struct Signature {
-    /// The affine coordinate of the random point generated during signing
-    pub x: Fp6,
+    /// The compressed random point generated during signing
+    pub x: CompressedPoint,
     /// The exponent from the random scalar, the private key
     /// and the output of the hash seen as a `Scalar` element
     pub e: Scalar,
@@ -42,7 +42,7 @@ pub struct Signature {
 impl ConditionallySelectable for Signature {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Signature {
-            x: Fp6::conditional_select(&a.x, &b.x, choice),
+            x: CompressedPoint::conditional_select(&a.x, &b.x, choice),
             e: Scalar::conditional_select(&a.e, &b.e, choice),
         }
     }
@@ -64,7 +64,7 @@ impl Signature {
 
         let e = r - skey.0 * h_scalar;
         Signature {
-            x: r_point.get_x(),
+            x: r_point.to_compressed(),
             e,
         }
     }
@@ -89,7 +89,7 @@ impl Signature {
 
         let e = r - skey.0 * h_scalar;
         Signature {
-            x: r_point.get_x(),
+            x: r_point.to_compressed(),
             e,
         }
     }
@@ -113,7 +113,7 @@ impl Signature {
 
         let e = r - keypair.private_key.0 * h_scalar;
         Signature {
-            x: r_point.get_x(),
+            x: r_point.to_compressed(),
             e,
         }
     }
@@ -124,7 +124,9 @@ impl Signature {
             return Err(SignatureError::InvalidPublicKey);
         }
 
-        let h = hash_message(&self.x, pkey, message);
+        let x_felt = Fp6::from_bytes(&self.x.0[0..48].try_into().unwrap()).unwrap();
+
+        let h = hash_message(&x_felt, pkey, message);
         let h_bits = h.as_bits::<Lsb0>();
 
         // Reconstruct a scalar from the binary sequence of h
@@ -136,7 +138,7 @@ impl Signature {
             .0
             .multiply_double_with_basepoint_vartime(&h_scalar.to_bytes(), &self.e.to_bytes());
 
-        if r.get_x() == self.x {
+        if r.get_x() == x_felt {
             Ok(())
         } else {
             Err(SignatureError::InvalidSignature)
@@ -146,23 +148,23 @@ impl Signature {
     /// Converts this signature to an array of bytes
     pub fn to_bytes(&self) -> [u8; SIGNATURE_LENGTH] {
         let mut output = [0u8; SIGNATURE_LENGTH];
-        output[0..BASEFIELD_LENGTH].copy_from_slice(&self.x.to_bytes());
-        output[BASEFIELD_LENGTH..SIGNATURE_LENGTH].copy_from_slice(&self.e.to_bytes());
+        output[0..BASEFIELD_LENGTH + 1].copy_from_slice(&self.x.to_bytes());
+        output[BASEFIELD_LENGTH + 1..SIGNATURE_LENGTH].copy_from_slice(&self.e.to_bytes());
 
         output
     }
 
     /// Constructs a signature from an array of bytes
     pub fn from_bytes(bytes: &[u8; SIGNATURE_LENGTH]) -> CtOption<Self> {
-        let mut array = [0u8; BASEFIELD_LENGTH];
-        array.copy_from_slice(&bytes[0..BASEFIELD_LENGTH]);
-        let x = Fp6::from_bytes(&array);
+        let mut array = [0u8; BASEFIELD_LENGTH + 1];
+        array.copy_from_slice(&bytes[0..BASEFIELD_LENGTH + 1]);
+        let x = CompressedPoint::from_bytes(&array);
 
         let mut array = [0u8; SCALAR_LENGTH];
-        array.copy_from_slice(&bytes[BASEFIELD_LENGTH..SIGNATURE_LENGTH]);
+        array.copy_from_slice(&bytes[BASEFIELD_LENGTH + 1..SIGNATURE_LENGTH]);
         let e = Scalar::from_bytes(&array);
 
-        x.and_then(|x| e.and_then(|e| CtOption::new(Signature { x, e }, Choice::from(1u8))))
+        e.and_then(|e| CtOption::new(Signature { x, e }, Choice::from(1u8)))
     }
 }
 
@@ -194,7 +196,7 @@ impl KeyedSignature {
 
         let e = r - skey.0 * h_scalar;
         let signature = Signature {
-            x: r_point.get_x(),
+            x: r_point.to_compressed(),
             e,
         };
 
@@ -264,7 +266,10 @@ impl KeyedSignature {
             KeyedSignature {
                 public_key: public_key.unwrap_or(PublicKey(AffinePoint::generator())),
                 signature: signature.unwrap_or(Signature {
-                    x: Fp6::zero(),
+                    x: CompressedPoint([
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128,
+                    ]),
                     e: Scalar::zero(),
                 }),
             },
@@ -405,7 +410,10 @@ mod test {
 
         {
             let wrong_signature_1 = Signature {
-                x: Fp6::zero(),
+                x: CompressedPoint([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128,
+                ]),
                 e: signature.e,
             };
             assert!(wrong_signature_1.verify(&message, &pkey).is_err());
@@ -424,27 +432,33 @@ mod test {
     fn test_encoding() {
         assert_eq!(
             Signature {
-                x: Fp6::one(),
+                x: CompressedPoint([
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                ]),
                 e: Scalar::zero(),
             }
             .to_bytes(),
             [
                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             ]
         );
 
         assert_eq!(
             Signature {
-                x: Fp6::zero(),
+                x: CompressedPoint([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                ]),
                 e: Scalar::one(),
             }
             .to_bytes(),
             [
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             ]
         );
 
@@ -452,7 +466,10 @@ mod test {
             KeyedSignature {
                 public_key: PublicKey(AffinePoint::identity()),
                 signature: Signature {
-                    x: Fp6::zero(),
+                    x: CompressedPoint([
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ]),
                     e: Scalar::one(),
                 },
             }
@@ -461,8 +478,8 @@ mod test {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ]
         );
 
@@ -471,7 +488,7 @@ mod test {
 
         for _ in 0..100 {
             let sig = Signature {
-                x: Fp6::random(&mut rng),
+                x: AffinePoint::random(&mut rng).to_compressed(),
                 e: Scalar::random(&mut rng),
             };
             let pkey = PublicKey(AffinePoint::random(&mut rng));
@@ -499,7 +516,7 @@ mod test {
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         ];
         let recovered_sig = Signature::from_bytes(&bytes);
         assert!(bool::from(recovered_sig.is_none()))

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -29,7 +29,7 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 use serde::{Deserialize, Serialize};
 
 /// A Schnorr signature not attached to its message.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 pub struct Signature {
     /// The compressed random point generated during signing


### PR DESCRIPTION
This PR introduces batch verification of Schnorr signatures.
For this purpose, it changes the field of the `Signature` struct corresponding to the x-coordinate of the random point sampled by the signer, to store information of the y-coordinate so that batching is possible. Another way around this would be to choose only lexicographically largest (or smallest) y-coordinates when reconstructing the point, similarly to what Bitcoin does. This would reduce the signature size from 81 bytes to 80 but would require an additional check during the verification procedure.

This PR also changes the hash instantiation to RP-64-12-8, much faster than the current RP-64-8-4 and able to handle higher throughput. This leads to a reduction in signing (with private key), signing (with keypair) and verifying of respectively 28%, 45% and 12%.

Batch verification yields on my machine an amortized verification time per signature of 335us for the benchmarked batch sizes, vs 394us for regular verification of a single signature. The gain is limited by the need of recomputing individually all the y-coordinates, which involves computing a square root in Fp6.